### PR TITLE
Add conditions ESRAP-ERROR, [SIMPLE-]ESRAP-PARSE-ERROR, LEFT-RECURSION

### DIFF
--- a/doc/esrap.texinfo
+++ b/doc/esrap.texinfo
@@ -192,6 +192,11 @@ whatever the predicate function returns.}
 
 @chapter Dictionary
 
+@include condition-esrap-esrap-error.texinfo
+@include condition-esrap-esrap-parse-error.texinfo
+@include condition-esrap-simple-esrap-parse-error.texinfo
+@include condition-esrap-left-recursion.texinfo
+
 @include include/macro-esrap-defrule.texinfo
 
 @include include/fun-esrap-add-rule.texinfo

--- a/esrap.lisp
+++ b/esrap.lisp
@@ -36,6 +36,16 @@
   (:export
    #:&bounds
 
+   #:format-error-position
+   #:esrap-error
+   #:esrap-parse-error
+   #:esrap-parse-error-text
+   #:esrap-parse-error-position
+   #:simple-esrap-parse-error
+   #:left-recursion
+   #:left-recursion-nonterminal
+   #:left-recursion-path
+
    #:! #:? #:+ #:* #:& #:~
    #:add-rule
    #:change-rule
@@ -51,10 +61,130 @@
    #:rule-symbol
    #:text
    #:trace-rule
-   #:untrace-rule
-   ))
+   #:untrace-rule))
 
 (in-package :esrap)
+
+;;; CONDITIONS
+
+(define-condition esrap-error (error)
+  ()
+  (:documentation
+   "Superclass of all esrap error conditions."))
+
+(define-condition esrap-parse-error (error)
+  ((text     :initarg  :text
+             :type     string
+             :reader   esrap-parse-error-text
+             :documentation
+             "The source string which was being parsed when the error
+              was encountered.")
+   (position :initarg  :position
+             :type     (or null (interger 0))
+             :reader   esrap-parse-error-position
+             :initform nil
+             :documentation
+             "The position in the source string at which the error was
+              encountered or nil if the position is not available."))
+  (:default-initargs
+   :text (required-argument :text))
+  (:report (lambda (condition stream)
+             (format stream "~@<Parse error~/esrap::format-error-position/~@:>"
+                     condition)))
+  (:documentation
+   "Instances of this error and its subclasses are signaled when an
+esrap parse fails."))
+
+(define-condition simple-esrap-parse-error (esrap-parse-error
+                                            simple-error)
+  ()
+  (:report (lambda (condition stream)
+             (format stream "~?~/esrap::format-error-position/"
+                     (simple-condition-format-control condition)
+                     (simple-condition-format-arguments condition)
+                     condition)))
+  (:documentation
+   "Like `esrap-parse-error' but additionally accepts format-control
+and format-arguments like `cl:simple-error'."))
+
+(defun simple-esrap-parse-error (text position format-control
+                                 &rest format-arguments)
+  "Signal a `simple-esrap-parse-error' for an error which occurred at
+POSITION of TEXT. FORMAT-CONTROL and FORMAT-ARGUMENTS work as for
+`cl:simple-error' s produced by `cl:error'."
+  (error 'simple-esrap-parse-error
+         :text             text
+         :position         position
+         :format-control   format-control
+         :format-arguments format-arguments))
+
+(define-condition left-recursion (esrap-parse-error)
+  ((nonterminal :initarg  :nonterminal
+                :type     symbol
+                :reader   left-recursion-nonterminal
+                :documentation
+                "The symbol naming the nonterminal for which the left
+                 recursion has been detected.")
+   (path        :initarg  :path
+                :type     list
+                :reader   left-recursion-path
+                :documentation
+                "A list of names of the nonterminals of which the left
+                 recursion cycle consists."))
+  (:default-initargs
+   :nonterminal (required-argument :nonterminal)
+   :path        (required-argument :path))
+  (:report (lambda (condition stream)
+             (format stream "Left recursion in nonterminal ~S. ~_Path: ~
+                             ~{~S~^ -> ~}~/esrap::format-error-position/"
+                     (left-recursion-nonterminal condition)
+                     (left-recursion-path        condition)
+                     condition)))
+  (:documentation
+   "This error is signaled when left recursion is detected during
+parsing."))
+
+(defun format-error-position (stream condition &optional at-p colon-p)
+  "Format the position information contained in CONDITION onto
+STREAM."
+  (declare (ignore at-p colon-p))
+  (when (or (not *print-lines*) (> *print-lines* 1))
+    (if-let ((text     (esrap-parse-error-text     condition))
+             (position (esrap-parse-error-position condition)))
+      (let* ((line   (count #\Newline text :end position))
+             (column (- position (or (position #\Newline text
+                                               :end      position
+                                               :from-end t)
+                                     0)
+                        1))
+             (start (or (position #\Newline text
+                                  :start    (max 0 (- position 32))
+                                  :end      (max 0 (- position 24))
+                                  :from-end t)
+                        (max 0 (- position 24))))
+             (end (min (length text) (+ position 24)))
+             (newline (or (position #\Newline text
+                                    :start    start
+                                    :end      position
+                                    :from-end t)
+                          start))
+             (*print-circle* nil))
+        (format stream
+                "~2&  Encountered at:~&    ~V@Tv (Line ~D, Column ~D, Position ~
+                 ~D)~&~@<  | ~@;~A~:@>"
+                (- position newline)
+                (1+ line) (1+ column)
+                position
+                (if (emptyp text)
+                    ""
+                    (concatenate 'string
+                                 (subseq text start position)
+                                 ">"
+                                 (subseq text position (1+ position))
+                                 "<"
+                                 (subseq text (1+ position) end)))))
+      (format stream "~2&  <Input and position information not ~
+                    available>"))))
 
 ;;; Miscellany
 
@@ -315,14 +445,17 @@ symbols."
 (defvar *nonterminal-stack* nil)
 
 ;;; SYMBOL, POSITION, and CACHE must all be lexical variables!
-(defmacro with-cached-result ((symbol position) &body forms)
+(defmacro with-cached-result ((symbol position &optional (text nil)) &body forms)
   (with-gensyms (cache result)
     `(let* ((,cache *cache*)
             (,result (get-cached ,symbol ,position ,cache))
             (*nonterminal-stack* (cons ,symbol *nonterminal-stack*)))
        (cond ((eq t ,result)
-              (error "Left recursion in nonterminal ~S, at ~S.~%Path: ~{~S~^ -> ~}"
-                     ,symbol ,position (nreverse *nonterminal-stack*)))
+              (error 'left-recursion
+                     :text        ,text
+                     :position    ,position
+                     :nonterminal ,symbol
+                     :path        (nreverse *nonterminal-stack*)))
              (,result
               ,result)
              (t
@@ -418,31 +551,28 @@ are allowed only if JUNK-ALLOWED is true."
       (if junk-allowed
           (values nil 0)
           (if (failed-parse-p result)
-              (error "Parse error:~%~A"
-                     (with-output-to-string (s)
-                       (format s " Expression ~S"
-                               (failed-parse-expression result))
-                       (labels ((rec (e)
-                                  (when e
-                                    (format s "~&   subexpression ~S"
-                                            (failed-parse-expression e))
-                                    (rec (failed-parse-detail e)))))
-                         (rec (failed-parse-detail result))
-                         (let* ((position (failed-parse-position result))
-                                (start (max 0 (- position 24)))
-                                (end (min (length text) (+ position 24))))
-                           (format s "~& failed at:~&   \"~A\"" (subseq text start end))
-                           (format s "~&    ~A^"
-                                   (make-string (- position start)
-                                                :initial-element #\space))))))
-              (error "Parse error: rule ~S not active"
-                     (inactive-rule-name result))))
+              (labels ((expressions (e)
+                         (when e
+                           (cons (failed-parse-expression e)
+                                 (expressions (failed-parse-detail e))))))
+                (let ((expressions (expressions result)))
+                  (simple-esrap-parse-error
+                   text (failed-parse-position result)
+                   "Could not parse subexpression ~S when parsing~2&~<  ~
+                    Expression ~S~@{~&    Subexpression ~S~}~:>"
+                   (lastcar expressions)
+                   expressions)))
+              (simple-esrap-parse-error
+               text nil "rule ~S not active"
+               (inactive-rule-name result))))
       (let ((position (result-position result)))
         (values (result-production result)
                 (when (< position end)
                   (if junk-allowed
                       position
-                      (error "Incomplete parse, stopped at ~S." position)))))))
+                      (simple-esrap-parse-error
+                       text position
+                       "Incomplete parse.")))))))
 
 (defmacro defrule (&whole form symbol expression &body options)
   "Define SYMBOL as a nonterminal, using EXPRESSION as associated the parsing expression.
@@ -772,20 +902,20 @@ inspection."
                                                 (result-position result)))))))
              (if (eq t condition)
                  (named-lambda rule/transform (text position end)
-                   (with-cached-result (symbol position)
+                   (with-cached-result (symbol position text)
                      (exec-rule/transform text position end)))
                  (named-lambda condition-rule/transform (text position end)
-                   (with-cached-result (symbol position)
+                   (with-cached-result (symbol position text)
                      (if (funcall condition)
                          (exec-rule/transform text position end)
                          rule-not-active))))))
           (t
            (if (eq t condition)
                (named-lambda rule (text position end)
-                 (with-cached-result (symbol position)
+                 (with-cached-result (symbol position text)
                    (funcall function text position end)))
                (named-lambda conditional-rule (text position end)
-                 (with-cached-result (symbol position)
+                 (with-cached-result (symbol position text)
                    (if (funcall condition)
                        (funcall function text position end)
                        rule-not-active))))))))

--- a/tests.lisp
+++ b/tests.lisp
@@ -125,6 +125,8 @@
           (declare (ignore whitespace))
           (cons token list)))))
 
+(defrule left-recursion (and left-recursion "l"))
+
 (defun bounds-test.1 ()
   (is (equal '("foo[0-3]")
              (parse 'tokens/bounds.1 "foo")))
@@ -137,10 +139,49 @@
   (is (equal '("foo(0-3)" "bar(4-7)" "quux(11-15)")
              (parse 'tokens/bounds.2 "foo bar    quux"))))
 
+(defun condition-test.1 ()
+  (macrolet
+      ((signals-parse-error ((input position &optional messages) &body body)
+         `(progn
+            (signals (esrap-parse-error)
+              ,@body)
+            (handler-case (progn ,@body)
+              (esrap-parse-error (condition)
+                (is (string= (esrap-parse-error-text     condition) ,input))
+                (is (=       (esrap-parse-error-position condition) ,position))
+		,@(when messages
+		    `((let ((report (princ-to-string condition)))
+			,@(mapcar (lambda (message)
+				    `(is (search ,message report)))
+				  (ensure-list messages))))))))))
+    (signals-parse-error ("" 0 ("Could not parse subexpression"
+				"Encountered at"))
+      (parse 'integer ""))
+    (signals-parse-error ("123foo" 3 ("Could not parse subexpression"
+				      "Encountered at"))
+      (parse 'integer "123foo"))
+    (signals-parse-error ("1, " 1 ("Incomplete parse."
+				   "Encountered at"))
+      (parse 'list-of-integers "1, "))))
+
+(defun condition-test.2 ()
+  (signals (left-recursion)
+    (parse 'left-recursion "l"))
+  (handler-case (parse 'left-recursion "l")
+    (left-recursion (condition)
+      (is (string= (esrap-parse-error-text     condition) "l"))
+      (is (=       (esrap-parse-error-position condition) 0))
+      (is (eq      (left-recursion-nonterminal condition)
+                   'left-recursion))
+      (is (equal   (left-recursion-path        condition)
+                   '(left-recursion left-recursion))))))
+
 (test esrap
   (smoke-test)
   (bounds-test.1)
-  (bounds-test.2))
+  (bounds-test.2)
+  (condition-test.1)
+  (condition-test.2))
 
 (defun run-tests ()
   (let ((results (run 'esrap)))


### PR DESCRIPTION
- This patch adds condition classes
  `ESRAP-ERROR` is the superclass for esrap conditions
  `ESRAP-PARSE-ERROR` is the superclass for parse errors
  `SIMPLE-ESRAP-PARSE-ERROR` is a `SIMPLE-ERROR` and `ESRAP-PARSE-ERROR`
  `LEFT-RECURSION` is a `ESRAP-PARSE-ERROR` that is signaled when left recursion is detected
- `PARSE` signals these errors
  failed parse     -> `SIMPLE-ESRAP-PARSE-ERROR`
  rule not active  -> `SIMPLE-ESRAP-PARSE-ERROR`
  incomplete parse -> `SIMPLE-ESRAP-PARSE-ERROR`
  left recursion   -> `LEFT-RECURSION`
- Position indication in condition reports is also slightly better:

```
> Could not parse subexpression #1=(OR (& #\,) (! CHARACTER)) when parsing
>
>   Expression INTEGER
>     Subexpression (AND #2=(? WHITESPACE) DIGITS #3=(AND #2# #1#))
>     Subexpression #3#
>     Subexpression #1#
>
>   Encountered at:
>         v (Line 1, Column 4, Position 3)
>     "123foo"
>    [Condition of type SIMPLE-ESRAP-PARSE-ERROR]
```
