### PR TITLE
Add support for character ranges

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,7 @@ Syntax overview:
  (~ <literal>)             -- case-insensitive terminal
  character                 -- any single character
  (string length)           -- any string of length
+ (character-ranges ranges) -- character ranges
  (and &rest sequence)
  (or &rest ordered-choises)
  (* greedy-repetition)

--- a/TODO.org
+++ b/TODO.org
@@ -53,8 +53,9 @@ Esrap TODO
 
 *** Character ranges
     (or "0" "1" "2" "3" "4" "5" "6" "7" "8" "9") can be implemented
-    with a range-check for char-code. Similarly (or "foobar" "foo"
-    "bar") can be implemented using tricks from pkhuong's STRING-CASE.
+    as (character-ranges (#\0 #\9)) now. The code likely needs 
+    improvement. Similarly (or "foobar" "foo" "bar") can be 
+    implemented using tricks from pkhuong's STRING-CASE.
 * Grammar objects
   Rules should be contained in grammars, so that symbols like CL:IF
   can refer to different rules in different contexts. Grammars can

--- a/doc/esrap.texinfo
+++ b/doc/esrap.texinfo
@@ -86,6 +86,11 @@ Expressions of the form @code{(string length)} can be used
 to specify sequences of arbitrary characters: @code{(string 2)} succeeds
 and consumes input as if @code{(and character character)}.
 @end itemize
+@item
+Expressions of the form @code{(character-ranges range ...)}
+A character-range pseudoterminal matches if there is a character left
+and it is inside one of the given ranges. Range can be specified like
+(#\a #\z) or be a simple character.
 
 Both normal terminals and pseudoterminals produce the consumed input
 as a string.

--- a/tests.lisp
+++ b/tests.lisp
@@ -191,6 +191,17 @@
     (is (equal "Foo" t3c))
     (is (equal "Foo" t3e))))
 
+(defrule character-range (character-ranges (#\a #\b) #\-))
+
+(defun character-range-test ()
+  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab" :junk-allowed t)))
+  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab1" :junk-allowed t)))
+  (is (equal '(#\a #\b #\-) (parse '(* (character-ranges (#\a #\z) #\-)) "ab-" :junk-allowed t)))
+  (is (or
+	(equal '() (parse '(* (character-ranges (#\a #\z) #\-)) "AB-" :junk-allowed t))
+	(equal '() (parse '(* (character-ranges (#\a #\z) #\-)) "ZY-" :junk-allowed t))))
+  (is (equal '(#\a #\b #\-) (parse '(* character-range) "ab-cd" :junk-allowed t))))
+
 (test esrap
   (smoke-test)
   (bounds-test.1)


### PR DESCRIPTION
I wrote a esrap-peg package to provide full PEG support on top of Esrap parsing core. Currently Esrap-PEG uses generating semantic predicates on the fly for character ranges. This pull request adds character range support into esrap itself.
