### PR TITLE
Forbid compiler macro for parse for ECL - it seems to break everything, ...

### DIFF
--- a/esrap.lisp
+++ b/esrap.lisp
@@ -483,6 +483,7 @@ are allowed only if JUNK-ALLOWED is true."
      end
      junk-allowed)))
 
+#-ecl
 (define-compiler-macro parse (&whole form expression &rest arguments
                               &environment env)
   (if (constantp expression env)


### PR DESCRIPTION
...unfortunately

It may be or not be a bug in ECL, or a case of unspecified corner case in the standard where ECL just turned out to be less tolerant.
