### PR TITLE
Add GRAMMAR structure and dependencies between grammars

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -9,7 +9,7 @@ Esrap TODO
 
     ...and even if the whole parse fails, we use the additional
     information only to display a fancy error message.
-    
+
     So: unless PARSE has been called with :DEBUG T, use the fixnum
     indicating the position to indicate a failed parse.
 
@@ -50,12 +50,10 @@ Esrap TODO
     Maybe: PCL-style multikey cache.
 
     Maybe: Basic two-level cache. (Version of this on a branch.)
-
-* Grammar objects
-  Rules should be contained in grammars, so that symbols like CL:IF
-  can refer to different rules in different contexts. Grammars can
-  also enforce rule numbering, making caching results easier. It
-  should be possible to inherit from other grammars.
+*** Character ranges
+    (or "0" "1" "2" "3" "4" "5" "6" "7" "8" "9") can be implemented
+    with a range-check for char-code. Similarly (or "foobar" "foo"
+    "bar") can be implemented using tricks from pkhuong's STRING-CASE.
 * Character classes
   Have a standard-grammar that defines things like DIGIT, WHITESPACE,
   ASCII, etc.
@@ -68,5 +66,3 @@ Esrap TODO
 * Transform Subseq
   (defrule decimal (+ (or "0" "1" ...))
     (:subseq-function parse-integer))
-
-

--- a/doc/esrap.texinfo
+++ b/doc/esrap.texinfo
@@ -103,14 +103,6 @@ and an optional transformation rule.
 
 Nonterminals are defined using @code{defrule}.
 
-@emph{Note: Currently all rules share the same namespace, so you
-should not use symbols in the COMMON-LISP package or other shared
-packages to name your rules unless you are certain there are no other
-Esrap using components in your Lisp image. In a future version of
-Esrap grammar objects will be introduced to allow multiple definitions
-of nonterminals. Symbols in the COMMON-LISP package are specifically
-reserved for use by Esrap.}
-
 @heading Sequence
 @lisp
 (and subexpression ...)
@@ -202,9 +194,47 @@ semantic predicate produces whatever the subexpression produces.
 @emph{Note: semantic predicates may change in the future to produce
 whatever the predicate function returns.}
 
+@chapter Grammars
+
+Esrap uses grammar objects to organize sets of rules into reusable
+units. Grammar objects are similar to Common Lisp packages in that they
+consist of
+@enumerate
+
+@item A name
+
+@item A set of used grammars
+
+@item A set of rules
+
+@item An optional documentation string
+
+@end enumerate
+
+Similarly to Common Lisp packages, when one grammar uses another
+grammar, the rules of the used grammar are available as nonterminals in
+rules of the using grammar. However, there are no explicit exported
+rules or name conflicts since rules are named by symbols and can thus
+leverage the mechanisms already provided by the package system.
+
+Redefinitions or grammars and rules are tracked across grammar
+dependencies in order always ensure a consistent state.
+
+@emph{Note: since some of these updates are rather complex, bugs should
+be expected and reported, when encountered.}
+
 @chapter Dictionary
 
 @section Primary Interface
+
+@heading Grammar Objects
+
+@include include/macro-esrap-defgrammar.texinfo
+
+@include include/var-esrap-star-grammar-star.texinfo
+@include include/macro-esrap-in-grammar.texinfo
+
+@heading Rules
 
 @include include/macro-esrap-defrule.texinfo
 @include include/fun-esrap-parse.texinfo
@@ -214,20 +244,41 @@ whatever the predicate function returns.}
 
 @include include/fun-esrap-text.texinfo
 
-@section Introspection and Intercession
+@section Grammar Introspection and Intercession
 
-@include include/fun-esrap-add-rule.texinfo
-@include include/fun-esrap-change-rule.texinfo
-@include include/fun-esrap-find-rule.texinfo
-@include include/fun-esrap-remove-rule.texinfo
+@include include/fun-esrap-grammar-name.texinfo
+@include include/fun-esrap-grammar-dependencies.texinfo
+@include include/fun-esrap-grammar-rules.texinfo
+
+@include include/fun-esrap-find-grammar.texinfo
+@include include/fun-esrap-setf-find-grammar.texinfo
+@include include/fun-esrap-make-grammar.texinfo
+
+@section Rule Introspection and Intercession
+
+@include include/fun-esrap-rule-symbol.texinfo
 @include include/fun-esrap-rule-dependencies.texinfo
 @include include/fun-esrap-rule-expression.texinfo
 @include include/fun-esrap-setf-rule-expression.texinfo
-@include include/fun-esrap-rule-symbol.texinfo
+
+@include include/fun-esrap-find-rule.texinfo
+@include include/fun-esrap-add-rule.texinfo
+@include include/fun-esrap-remove-rule.texinfo
+@include include/fun-esrap-change-rule.texinfo
+
 @include include/fun-esrap-trace-rule.texinfo
 @include include/fun-esrap-untrace-rule.texinfo
 
 @section Error Conditions
+
+@include include/condition-esrap-grammar-not-found-error.texinfo
+@include include/condition-esrap-grammar-not-found-warning.texinfo
+
+@include include/condition-esrap-rule-not-found-error.texinfo
+@include include/condition-esrap-rule-not-found-warning.texinfo
+
+@include include/condition-esrap-invalid-expression-error.texinfo
+@include include/condition-esrap-invalid-expression-warning.texinfo
 
 @include include/condition-esrap-esrap-error.texinfo
 @include include/condition-esrap-left-recursion.texinfo

--- a/esrap.asd
+++ b/esrap.asd
@@ -22,7 +22,7 @@
 (in-package :esrap-system)
 
 (defsystem :esrap
-  :version "0.9"
+  :version "0.10"
   :description "A Packrat / Parsing Grammar / TDPL parser for Common Lisp."
   :licence "MIT"
   :depends-on (:alexandria)

--- a/esrap.asd
+++ b/esrap.asd
@@ -28,6 +28,7 @@
   :depends-on (:alexandria)
   :components ((:file "esrap")
                (:static-file "example-sexp.lisp")
+               (:static-file "example-sexp-xml.lisp")
                (:static-file "example-symbol-table.lisp")
                (:static-file "README")))
 

--- a/esrap.lisp
+++ b/esrap.lisp
@@ -33,25 +33,55 @@
   (:use :cl :alexandria)
   #+sbcl
   (:lock t)
+
+  ;; Special symbols
   (:export
    #:&bounds
 
    #:! #:? #:+ #:* #:& #:~
    #:character-ranges
 
+   #:*grammar*)
+
+  ;; Conditions
+  (:export
+   #:grammar-not-found-name
+   #:grammar-not-found-error
+   #:grammar-not-found-warning
+
+   #:rule-not-found-grammar
+   #:rule-not-found-name
+   #:rule-not-found-error
+   #:rule-not-found-warning
+
+   #:invalid-expression-expression
+   #:invalid-expression-error
+   #:invalid-expression-warning
+
+   #:esrap-error
+   #:esrap-error-position
+   #:esrap-error-text
+
+   #:left-recursion
+   #:left-recursion-nonterminal
+   #:left-recursion-path)
+
+  ;; Functions
+  (:export
    #:add-rule
    #:call-transform
    #:change-rule
    #:concat
+   #:defgrammar
    #:defrule
    #:describe-grammar
-   #:esrap-error
-   #:esrap-error-position
-   #:esrap-error-text
+   #:find-grammar
    #:find-rule
-   #:left-recursion
-   #:left-recursion-nonterminal
-   #:left-recursion-path
+   #:grammar-name
+   #:grammar-rules
+   #:grammar-dependencies
+   #:in-grammar
+   #:make-grammar
    #:parse
    #:remove-rule
    #:rule
@@ -65,7 +95,81 @@
 
 (in-package :esrap)
 
-;;; Conditions
+;;; CONDITIONS
+
+(define-condition grammar-not-found (condition)
+    ((name :initarg :name :reader grammar-not-found-name))
+  (:default-initargs
+   :name (required-argument :name)))
+
+(defmethod print-object ((condition grammar-not-found) stream)
+  (format stream "The grammar named ~S could not be found."
+          (grammar-not-found-name condition)))
+
+(define-condition grammar-not-found-error (error
+                                           grammar-not-found)
+  ()
+  (:documentation
+   "Signaled when a grammar is requested by name but cannot be
+found."))
+
+(define-condition grammar-not-found-warning (warning
+                                             grammar-not-found)
+  ()
+  (:documentation
+   "Signaled when it can be determined at compile time that a
+requested grammar cannot be found."))
+
+(define-condition rule-not-found (condition)
+  ((grammar :initarg :grammar :reader rule-not-found-grammar)
+   (name :initarg :name :reader rule-not-found-name))
+  (:default-initargs
+   :grammar (required-argument :grammar)
+   :name (required-argument :name)))
+
+(defmethod print-object ((condition rule-not-found) stream)
+  (format stream "The rule named ~S could not be found~@[ in grammar ~A~]."
+          (rule-not-found-name condition)
+          (rule-not-found-grammar condition)))
+
+(define-condition rule-not-found-error (error
+                                        rule-not-found)
+  ()
+  (:documentation
+   "Signaled when a rule is requested by name but cannot be found
+within a particular grammar."))
+
+(define-condition rule-not-found-warning (warning
+                                          rule-not-found)
+  ()
+  (:documentation
+   "Signaled when it can be determined at compile time that a
+requested rule cannot be found within a particular grammar."))
+
+(define-condition invalid-expression (condition)
+  ((expression :initarg :expression :reader invalid-expression-expression))
+  (:default-initargs
+   :expression (required-argument :expression)))
+
+(defmethod print-object ((condition invalid-expression) stream)
+  (format stream "Invalid expression: ~S"
+          (invalid-expression-expression condition)))
+
+(define-condition invalid-expression-error (error
+                                            invalid-expression)
+  ()
+  (:documentation
+   "Signaled when an invalid expression is encountered."))
+
+(defun invalid-expression-error (expression)
+  (error 'invalid-expression-error :expression expression))
+
+(define-condition invalid-expression-warning (warning
+                                              invalid-expression)
+  ()
+  (:documentation
+   "Signaled when it can be determined at compile time that a supplied
+expression is invalid."))
 
 (define-condition esrap-error (parse-error)
   ((text :initarg :text :initform nil :reader esrap-error-text)
@@ -225,6 +329,11 @@ for use with IGNORE."
       (check-type end symbol)
       (values lambda-list start end gensyms))))
 
+(deftype grammar-designator ()
+  "Things which can be coerced into STRINGs by CL:STRING can designate
+grammars."
+  '(or symbol string))
+
 (deftype nonterminal ()
   "Any symbol except CHARACTER and NIL can be used as a nonterminal symbol."
   '(and symbol (not (member character nil))))
@@ -237,20 +346,257 @@ and expressions of the form \(~ <literal>) denote case-insensitive terminals."
 
 ;;; RULE REPRESENTATION AND STORAGE
 ;;;
-;;; For each rule, there is a RULE-CELL in *RULES*, whose %INFO slot has the
-;;; function that implements the rule in car, and the rule object in CDR. A
-;;; RULE object can be attached to only one non-terminal at a time, which is
-;;; accessible via RULE-SYMBOL.
+;;; Each grammar, i.e. a named set of rules, is represented as a
+;;; GRAMMAR instance. Grammars are named by strings and can be
+;;; retrieved by name. In these regards, grammars behave similarly to
+;;; Common Lisp packages.
+;;;
+;;; Dependencies between grammars (:USE-relations) are managed via
+;;; GRAMMAR-REFERENTS and GRAMMAR-USE. Circular dependencies are
+;;; currently not allowed.
+;;;
+;;; For each rule, there is a RULE-CELL in GRAMMAR-RULES, whose %INFO
+;;; slot has the function that implements the rule in car, and the
+;;; rule object in CDR. A RULE object can be attached to only one
+;;; non-terminal at a time, which is accessible via RULE-SYMBOL.
 
-(defvar *rules* (make-hash-table))
+(defvar *grammars* (make-hash-table :test #'equal
+                                    #+sbcl :synchronized #+sbcl t)
+  "Global storage of grammar objects, indexed by STRINGified name.")
 
-(defun clear-rules ()
-  (clrhash *rules*)
+(defun find-grammar (grammar-designator
+                     &key
+                     (if-does-not-exist nil))
+  "Finds and returns the grammar designated by GRAMMAR-DESIGNATOR.
+
+IF-DOES-NOT-EXISTS determines the behavior in case no such grammar
+exists. If NIL, NIL is returned, if a function, the function is called
+with an error or warning condition object."
+  (check-type grammar-designator grammar-designator)
+  (check-type if-does-not-exist  (or null function symbol))
+
+  (let ((key (string grammar-designator)))
+    (or (gethash  key *grammars*)
+        (typecase if-does-not-exist
+          (null nil)
+          (function
+           (funcall if-does-not-exist
+                    (make-condition
+                     (cond
+                       ((member if-does-not-exist `(warn ,#'warn))
+                        'grammar-not-found-warning)
+                       (t
+                        'grammar-not-found-error))
+                     :name key)))))))
+
+(defun (setf find-grammar) (new-value grammar-designator
+                            &key
+                            if-does-not-exist)
+  "Stores GRAMMAR under the name GRAMMAR-DESIGNATOR.
+
+If GRAMMAR is NIL, deletes the grammar designated by
+GRAMMAR-DESIGNATOR. This signals a continuable error if the designated
+grammar is used by other grammars.
+
+IF-DOES-NOT-EXISTS is accepted for parity with FIND-GRAMMAR and
+ignored."
+  (declare (ignore if-does-not-exist))
+  (check-type grammar-designator grammar-designator)
+
+  ;; TODO(jmoringe, 2012-12-30): not thread-safe
+  (let* ((key      (string grammar-designator))
+         (existing (find-grammar grammar-designator
+                                 :if-does-not-exist nil)))
+    (cond
+      ;; When we are supposed to delete a grammar, find it and check
+      ;; whether it is used by other grammars. If we can remove it,
+      ;; dereference used grammars.
+      ((null new-value)
+       (when existing
+         (when-let ((refs (grammar-referents existing)))
+           (cerror "Force"
+                   "Grammar ~A is used by other grammar~P:~% ~{~A~^, ~}"
+                   existing (length refs) refs))
+         ;; Remove rules to potentially derefence rules in used
+         ;; grammars.
+         (clear-rules existing)
+         ;; Deference used grammars.
+         (mapc (rcurry #'dereference-grammar existing)
+               (grammar-use existing))
+         ;; Remove the grammar object.
+         (remhash key *grammars*)))
+
+      ;; When we are replacing an existing grammar, we check added
+      ;; and removed used grammars to detect cyclic usage relations
+      ;; and recompile rules as needed.
+      (existing
+       (flet ((diff-used (left right)
+                (set-difference (grammar-use left) (grammar-use right)
+                                :test #'eq)))
+         (let ((added-used   (diff-used new-value existing))
+               (removed-used (diff-used existing new-value)))
+
+           ;; If used grammars have been added, make sure none of
+           ;; these would introduce a cyclic usage relation.
+           (dolist (grammar added-used)
+             (when (member existing (grammar-use-closure grammar)
+                           :test #'eq)
+               ;; TODO(jmoringe, 2013-01-21): determine actual path;
+               ;; proper condition
+               (error "~@<Circular dependency with path:~_~{~A~^ -> ~}~@:>"
+                      (list existing grammar "..." existing))))
+
+           ;; Update the existing grammar with the new use-list and
+           ;; documentation. Keep existing rules.
+           (setf (grammar-use existing) (grammar-use new-value)
+                 (grammar-documentation existing) (grammar-documentation new-value))
+
+           ;; When used grammars have been added, reference them and
+           ;; recompile rules.
+           (when added-used
+             (format t "Use-list of ~A changed~%added: ~A~%" new-value added-used)
+             (mapc (rcurry #'reference-grammar existing) added-used)
+
+             (dolist (grammar (remove-duplicates
+                               (append added-used
+                                       (mapcan #'grammar-use-closure added-used))
+                               :test #'eq))
+               (format t "~2@TMaybe recompiling in ~A~%" grammar)
+               (dolist (cell (hash-table-values (grammar-rules grammar)))
+                 (when-let ((rule (cell-rule cell)))
+                   (format t "~4@TMaybe recompiling ~A in ~A~%" rule grammar)
+                   (update-rule-dependencies grammar cell (rule-symbol rule))))))
+
+           ;; When used grammars have been removed, dereference
+           ;; them. We have no choice but "detach" (dereference all
+           ;; referenced rules) and recompile all rules.
+           (when removed-used
+             (format t "Use-list of ~A changed~%removed: ~A~%"
+                     new-value removed-used)
+
+             (format t "~2@TRecompiling in ~A~%" existing)
+             (dolist (cell (hash-table-values (grammar-rules existing)))
+               (when-let ((rule (cell-rule cell)))
+                 (format t "~4@TRecompiling ~A in ~A~%" rule existing)
+                 (let ((use-new (grammar-use existing))) ; TODO hack
+                   (setf (grammar-use existing) (append use-new removed-used))
+                   (dereference-rule-dependencies existing rule)
+                   (setf (grammar-use existing) use-new))
+                 (recompile-cell existing cell)))
+
+             (mapc (rcurry #'dereference-grammar existing) removed-used))))
+       existing)
+
+      ;; When we are installing a new grammar, reference used grammars
+      ;; and store it.
+      (t
+       (mapc (rcurry #'reference-grammar new-value)
+             (grammar-use new-value))
+       (setf (gethash key *grammars*) new-value)))))
+
+(defun coerce-to-grammar (name-or-grammar &key (if-does-not-exist #'error))
+  "Finds and returns the grammar object designated by NAME-OR-GRAMMAR.
+If NAME-OR-GRAMMAR is a GRAMMAR, just returns it.
+
+IF-DOES-NOT-EXISTS determines the behavior in case no such grammar
+exists. If NIL, NIL is returned, if a function, the function is called
+with an error or warning condition object."
+  (etypecase name-or-grammar
+    (grammar-designator
+     (find-grammar name-or-grammar :if-does-not-exist if-does-not-exist))
+    (grammar
+     name-or-grammar)))
+
+(defstruct (grammar (:conc-name grammar-)
+                    (:constructor %make-grammar (name use &optional documentation)))
+  (name (required-argument :name) :type string :read-only t)
+  (rules (make-hash-table :test #'eq) :read-only t)
+  (use nil :type list)
+  (referents nil :type list)
+  (documentation nil :type (or null string)))
+
+(defun make-grammar (name &key use documentation)
+  "Makes and returns a grammar named NAME with use list USE and DOCUMENTATION.
+
+USE is a list of GRAMMAR-DESIGNATOR s designating the grammars used by
+the new grammar. If one or more of these designators does not name a
+grammar, an error is signaled.
+
+Note that this function has global side effects: The returned grammar
+is registered into the global grammar list and usage relations between
+grammars are established."
+  (check-type name grammar-designator)
+
+  (let* ((name (string name))
+         (used (mapcar #'coerce-to-grammar use))
+         (grammar (%make-grammar name used documentation)))
+    (setf (find-grammar name) grammar)))
+
+(macrolet ((frob (name reader)
+             `(defun ,name (grammar)
+                ,(format nil "Return ~S-closure for GRAMMAR." reader)
+                ;; This is only called on acyclic grammar
+                ;; graphs. Therefore, we do not check for cycles.
+                (labels ((recur (grammar)
+                           (remove-duplicates
+                            (cons grammar (mapcan #'recur (,reader grammar)))
+                            :test #'eq)))
+                  (mapcan #'recur (,reader grammar))))))
+  (frob grammar-use-closure grammar-use)
+  (frob grammar-referents-closure grammar-referents))
+
+(defun reference-grammar (grammar referent)
+  (check-type grammar grammar)
+  (check-type referent grammar)
+  (assert (not (eq grammar referent)))
+  (pushnew referent (grammar-referents grammar))
+  grammar)
+
+(defun dereference-grammar (grammar referent)
+  (check-type grammar grammar)
+  (check-type referent grammar)
+  (assert (not (eq grammar referent)))
+  (setf (grammar-referents grammar)
+        (delete referent (grammar-referents grammar)))
+  grammar)
+
+(defun grammar-dependencies (grammar)
+  "Returns the names of the grammars which are used by GRAMMAR."
+  (mapcar #'grammar-name (grammar-use grammar)))
+
+(defmethod print-object ((object grammar) stream)
+  (print-unreadable-object (object stream :type t :identity t)
+    (let ((use-count               (length (grammar-use object)))
+          (use-closure-count       (length (grammar-use-closure object)))
+          (referents-count         (length (grammar-referents object)))
+          (referents-closure-count (length (grammar-referents-closure object))))
+      (format stream "~S ~D rule~:P~
+                     ~[~*~:;, uses ~:*~D~[~:; + ~:*~D~]~]~
+                     ~[~*~:;, used by ~:*~D~[~:; + ~:*~D~]~]"
+              (grammar-name object)
+              (hash-table-count (grammar-rules object))
+              use-count (- use-closure-count use-count)
+              referents-count (- referents-closure-count referents-count)))))
+
+(defmethod documentation ((object grammar) (type (eql t)))
+  (grammar-documentation object))
+
+(defmethod documentation ((object t) (type (eql 'grammar)))
+  (when-let ((grammar (coerce-to-grammar object :if-does-not-exist nil)))
+    (documentation grammar t)))
+
+(defun clear-rules (grammar)
+  ;; Remove rules to potentially derefence rules in used grammars.
+  (mapc #'(lambda (cell)
+            (when-let ((rule (cell-rule cell)))
+              (remove-rule (rule-symbol rule) :grammar grammar :force t)))
+        (hash-table-values (grammar-rules grammar)))
+  (clrhash (grammar-rules grammar))
   nil)
 
 (defstruct (rule-cell (:constructor
                        make-rule-cell
-                       (symbol &aux (%info (cons (undefined-rule-function symbol) nil))))
+                       (symbol &aux (%info (cons (undefined-rule-function nil symbol) nil))))
                       (:conc-name cell-))
   (%info (required-argument) :type (cons function t))
   (trace-info nil)
@@ -269,35 +615,48 @@ and expressions of the form \(~ <literal>) denote case-insensitive terminals."
   (let ())
   cell)
 
-(defun undefined-rule-function (symbol)
+(defun undefined-rule-function (grammar symbol)
   (lambda (&rest args)
     (declare (ignore args))
-    (error "Undefined rule: ~S" symbol)))
+    (error 'rule-not-found-error :grammar grammar :name symbol)))
 
-(defun ensure-rule-cell (symbol)
+(defun find-rule-cell (grammar symbol &key (recursive t))
+  (check-type grammar grammar)
   (check-type symbol nonterminal)
-  ;; FIXME: Need to lock *RULES*.
-  (or (gethash symbol *rules*)
-      (setf (gethash symbol *rules*)
+  ;; Try to find the rule designated by SYMBOL in GRAMMAR.
+  (or (gethash symbol (grammar-rules grammar))
+      ;; Then look in grammars used by GRAMMAR.
+      (when recursive
+        (some (rcurry #'find-rule-cell symbol) (grammar-use grammar)))))
+
+(defun delete-rule-cell (grammar symbol)
+  (check-type grammar grammar)
+  (remhash symbol (grammar-rules grammar)))
+
+(defun ensure-rule-cell (grammar symbol)
+  (check-type grammar grammar)
+  (check-type symbol nonterminal)
+  ;; FIXME: Need to lock GRAMMAR-RULES.
+  (or (find-rule-cell grammar symbol)
+      (setf (gethash symbol (grammar-rules grammar))
             (make-rule-cell symbol))))
 
-(defun delete-rule-cell (symbol)
-  (remhash symbol *rules*))
+(defun reference-rule-cell (cell referent)
+  (check-type cell rule-cell)
+  (check-type referent (or null rule-cell))
+  (assert (not (eq cell referent)))
+  ;; REFERENT can be NIL when we are currently compiling an "inline"
+  ;; expression.
+  (when referent
+    (pushnew referent (cell-referents cell)))
+  cell)
 
-(defun reference-rule-cell (symbol referent)
-  (let ((cell (ensure-rule-cell symbol)))
-    (when referent
-      (pushnew referent (cell-referents cell)))
-    cell))
-
-(defun dereference-rule-cell (symbol referent)
-  (let ((cell (ensure-rule-cell symbol)))
-    (setf (cell-referents cell) (delete referent (cell-referents cell)))
-    cell))
-
-(defun find-rule-cell (symbol)
-  (check-type symbol nonterminal)
-  (gethash symbol *rules*))
+(defun dereference-rule-cell (cell referent)
+  (check-type cell rule-cell)
+  (check-type referent rule-cell)
+  (assert (not (eq cell referent)))
+  (setf (cell-referents cell) (delete referent (cell-referents cell)))
+  cell)
 
 (defclass rule ()
   ((%symbol
@@ -325,50 +684,140 @@ and expressions of the form \(~ <literal>) denote case-insensitive terminals."
     :initform nil
     :reader rule-around)))
 
+(defmethod shared-initialize :after ((rule rule) slots &key)
+  (check-expression (rule-expression rule)))
+
 (defun rule-symbol (rule)
   "Returns the nonterminal associated with the RULE, or NIL of the rule
 is not attached to any nonterminal."
   (slot-value rule '%symbol))
 
-(defun detach-rule (rule)
-  (dolist (dep (%rule-direct-dependencies rule))
-    (dereference-rule-cell dep (rule-symbol rule)))
-  (setf (slot-value rule '%symbol) nil))
-
-(defmethod shared-initialize :after ((rule rule) slots &key)
-  (validate-expression (rule-expression rule)))
+(defun rule-detached-p (rule)
+  "Returns non-NIL if RULE is not attached to any nonterminal."
+  (not (rule-symbol rule)))
 
 (defmethod print-object ((rule rule) stream)
   (print-unreadable-object (rule stream :type t :identity nil)
-    (let ((symbol (rule-symbol rule)))
-      (if symbol
-          (format stream "~S <- " symbol)
-          (format stream "(detached) ")))
-    (write (rule-expression rule) :stream stream)))
+    (format stream "~:[(detached)~;~:*~S <-~] ~S"
+            (rule-symbol rule)
+            (rule-expression rule))))
 
-(defun sort-dependencies (symbol dependencies)
+(defun sort-dependencies (grammar symbol dependencies)
   (let ((symbols (delete symbol dependencies))
         (defined nil)
         (undefined nil))
     (dolist (sym symbols)
-      (if (find-rule sym)
+      (if (find-rule sym :grammar grammar)
           (push sym defined)
           (push sym undefined)))
     (values defined undefined)))
 
-(defun rule-dependencies (rule)
+(defun rule-dependencies (rule &key (grammar *grammar*))
   "Returns the dependencies of the RULE: primary value is a list of defined
 nonterminal symbols, and secondary value is a list of undefined nonterminal
-symbols."
-  (sort-dependencies
-   (rule-symbol rule) (%expression-dependencies (rule-expression rule) nil)))
+symbols.
 
-(defun rule-direct-dependencies (rule)
+If supplied, GRAMMAR has to be be a GRAMMAR instance or some other
+object designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR
+does not designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled."
+  (check-type rule nonterminal)
+  (check-type grammar (or grammar grammar-designator))
+  (let* ((grammar (coerce-to-grammar grammar))
+         (rule    (find-rule rule :grammar grammar
+                                  :if-does-not-exist #'error)))
+    (sort-dependencies
+     grammar (rule-symbol rule)
+     (%expression-dependencies grammar (rule-expression rule) nil))))
+
+(defun rule-direct-dependencies (grammar rule)
+  (check-type grammar grammar)
+  (check-type rule rule)
   (sort-dependencies
-   (rule-symbol rule) (%expression-direct-dependencies (rule-expression rule) nil)))
+   grammar (rule-symbol rule)
+   (%expression-direct-dependencies (rule-expression rule) nil)))
 
 (defun %rule-direct-dependencies (rule)
-  (delete (rule-symbol rule) (%expression-direct-dependencies (rule-expression rule) nil)))
+  (check-type rule rule)
+  (delete (rule-symbol rule)
+          (%expression-direct-dependencies (rule-expression rule) nil)))
+
+(declaim (special *grammar*)
+         (type grammar *grammar*))
+
+(defvar *grammar* (make-grammar '#:default)
+  "The \"current\" grammar object.
+
+The value of this variable is used by DEFRULE if a grammar is not
+supplied explicitly.
+
+The initial global value is a grammar named \"DEFAULT\".")
+
+(defmacro defgrammar (name &body options)
+  "Define a new grammar named NAME, syntactically similar to
+CL:DEFPACKAGE. OPTIONS can be any of the following:
+
+* (:USE GRAMMAR-DESIGNATOR+)
+
+  Allow using rules defined in the grammar(s) designated by
+  GRAMMAR-DESIGNATOR+ in the grammar being defined.
+
+* (:DOCUMENTATION STRING)
+
+  Install STRING as the documentation string of the grammar being
+  defined.
+
+The :USE option can be supplied multiple times.
+
+When used grammars are cannot be found at compile time, a full warning
+is signaled. When used grammars are cannot be found at runtime, an
+error is signaled.
+
+Grammars can be redefined in a similar way packages can: if the
+redefinition would introduce an error (e.g. a used grammar cannot be
+found), the previous definition is kept. When the redefinition
+succeeds, existing rules are retained but may behave differently since
+added/removed used grammars can cause nonterminals to become defined
+or undefined."
+  (check-type name grammar-designator)
+
+  (let ((use '())
+        (documentation nil))
+    ;; Build and check use list. If used grammars cannot be found,
+    ;; still expand, but signal full warnings.
+    (dolist (option options)
+      (destructuring-bind (keyword &rest value) option
+        (ecase keyword
+          (:use
+           (dolist (used value)
+             (coerce-to-grammar used :if-does-not-exist #'warn))
+           (appendf use value))
+          (:documentation
+           (if documentation
+               (error "~@<~S supplied more than once.~@:>"
+                      keyword)
+               (setf documentation (first value)))))))
+
+    ;; MAKE-GRAMMAR signals an error at runtime if a used grammar
+    ;; cannot be found.
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       (make-grammar ,(string name)
+                     :use ',use
+                     :documentation ,documentation))))
+
+(defmacro in-grammar (name)
+  "Set *GRAMMAR* to the grammar named NAME.
+
+The grammar NAME has to exist at compile time of the IN-GRAMMAR form."
+  (check-type name grammar-designator)
+
+  ;; Signal a full warning if the grammar designated by NAME cannot be
+  ;; found at compile time.
+  (coerce-to-grammar name :if-does-not-exist #'warn)
+
+  ;; Signal an error at runtime, if the grammar cannot be found at
+  ;; runtime.
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (setf *grammar* (coerce-to-grammar ,(string name)))))
 
 ;;; Expression destructuring and validation
 
@@ -475,38 +924,99 @@ symbols."
 
 ;;; MAIN INTERFACE
 
-(defun parse (expression text &key (start 0) end junk-allowed)
-  "Parses TEXT using EXPRESSION from START to END. Incomplete parses
-are allowed only if JUNK-ALLOWED is true."
+(defun parse (expression text &key (grammar *grammar*)
+                                   (start 0) end junk-allowed)
+  "Parses TEXT using EXPRESSION in GRAMMAR from START to END.
+
+If supplied, GRAMMAR has to be be a GRAMMAR instance or some other
+object designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR
+does not designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled
+
+Incomplete parses are allowed only if JUNK-ALLOWED is true.
+
+If GRAMMAR and EXPRESSION are constant and either GRAMMAR cannot be
+found at compile time or EXPRESSION is not valid within GRAMMAR at
+compile time, a full warning is signaled at compile time."
   ;; There is no backtracking in the toplevel expression -- so there's
   ;; no point in compiling it as it will be executed only once -- unless
   ;; it's a constant, for which we have a compiler-macro.
-  (let ((end (or end (length text))))
+  (let ((grammar (coerce-to-grammar grammar))
+        (end (or end (length text))))
     (process-parse-result
      (let ((*cache* (make-cache)))
-       (eval-expression expression text start end))
+       (eval-expression grammar expression text start end))
      text
      end
      junk-allowed)))
 
 (define-compiler-macro parse (&whole form expression &rest arguments
                               &environment env)
-  (if (constantp expression env)
-      (with-gensyms (expr-fun)
-        `(let ((,expr-fun (load-time-value (compile-expression ,expression))))
-           ;; This inline-lambda here provides keyword defaults and
-           ;; parsing, so the compiler-macro doesn't have to worry
-           ;; about evaluation order.
-           ((lambda (text &key (start 0) end junk-allowed)
-              (let ((*cache* (make-cache))
-                    (end (or end (length text))))
-                (process-parse-result
-                 (funcall ,expr-fun text start end)
-                 text
-                 end
-                 junk-allowed)))
-            ,@arguments)))
-      form))
+  ;; If GRAMMAR is constant, we try and see whether it exists at
+  ;; compile time. We signal a full warning at compile time, if we
+  ;; cannot find it.
+  (let ((grammar (getf (rest arguments) :grammar)))
+    (cond
+      ;; GRAMMAR is constant => check it at compile time, then
+      ;; decline.
+      ((and grammar (constantp grammar env)
+            (not (constantp expression env)))
+       (coerce-to-grammar (eval grammar) :if-does-not-exist #'warn)
+       form)
+
+      ;; EXPRESSION is constant, but GRAMMAR is not => check
+      ;; EXPRESSION at compile time, then decline.
+      ((and (or (not grammar) (not (constantp grammar env)))
+            (constantp expression env))
+       (handler-case ;; TODO(jmoringe, 2013-01-27): ugly and also repeated in DEFRULE
+           (check-expression (eval expression))
+         (invalid-expression-error (condition)
+           (warn 'invalid-expression-warning
+                 :expression (invalid-expression-expression condition))))
+       form)
+
+      ;; GRAMMAR and EXPRESSION are constant => check both compile
+      ;; time and compile EXPRESSION at load time.
+      ((and grammar (constantp grammar env)
+            (constantp expression env)
+            (when-let ((grammar (coerce-to-grammar
+                                 (eval grammar)
+                                 :if-does-not-exist #'warn)))
+              ;; We could find the grammar, so we can try and also check
+              ;; EXPRESSION. Again, we signal a full warning at compile
+              ;; time, if EXPRESSION seems invalid.
+              (handler-case ;; TODO(jmoringe, 2013-01-27): ugly and also repeated in DEFRULE
+                  ;;; TODO(jmoringe, 2013-01-21): CHECK-EXPRESSION should support :if-invalid
+                  (progn (check-expression (eval expression) grammar) t)
+                (rule-not-found-error (condition)
+                  (warn 'rule-not-found-warning
+                        :grammar (rule-not-found-grammar condition)
+                        :name (rule-not-found-name condition)))
+                (invalid-expression-error (condition)
+                  (warn 'invalid-expression-warning
+                        :expression (invalid-expression-expression condition))
+                  nil))))
+
+       ;; Emit code to compile EXPRESSION at load time.
+       (with-gensyms (expr-fun)
+         `(let ((,expr-fun (load-time-value
+                            (compile-expression
+                             (coerce-to-grammar ,grammar) ,expression))))
+            ;; This inline-lambda here provides keyword defaults and
+            ;; parsing, so the compiler-macro doesn't have to worry
+            ;; about evaluation order.
+            ((lambda (text &key grammar (start 0) end junk-allowed)
+               (declare (ignore grammar))
+               (let ((*cache* (make-cache))
+                     (end (or end (length text))))
+                 (process-parse-result
+                  (funcall ,expr-fun text start end)
+                  text
+                  end
+                  junk-allowed)))
+             ,@arguments))))
+
+      ;; Nothing interesting is constant => decline.
+      (t form))))
 
 (defun process-parse-result (result text end junk-allowed)
   (if (error-result-p result)
@@ -533,8 +1043,25 @@ are allowed only if JUNK-ALLOWED is true."
                       position
                       (simple-esrap-error text position "Incomplete parse.")))))))
 
-(defmacro defrule (&whole form symbol expression &body options)
-  "Define SYMBOL as a nonterminal, using EXPRESSION as associated the parsing expression.
+(defmacro defrule (&whole form symbol-and-options expression &body options)
+  "Define SYMBOL-AND-OPTIONS as a nonterminal, using EXPRESSION as associated parsing expression.
+
+SYMBOL-AND-OPTIONS has to be one of:
+
+  * SYMBOL
+
+    Just names the new rule, no options.
+
+  * (SYMBOL &KEY GRAMMAR)
+
+    SYMBOL names the rule.
+
+    GRAMMAR is a GRAMMAR-DESIGNATOR designating the grammar to which
+    the new rule should be added.
+
+When the specified containing grammar cannot be found at compile time,
+a full warning is signaled. When the specified containing grammar
+cannot be found at runtime, an error is signaled.
 
 Following OPTIONS can be specified:
 
@@ -599,11 +1126,37 @@ Following OPTIONS can be specified:
     This option can be used to safely track nesting depth, manage symbol
     tables or for other stack-like operations.
 "
-  (let ((transform nil)
-        (around nil)
-        (guard t)
-        (condition t)
-        (guard-seen nil))
+  (let* ((symbol-and-options (ensure-list symbol-and-options))
+         (symbol (first symbol-and-options))
+         (grammar-designator (getf (rest symbol-and-options) :grammar))
+         (grammar (if (not grammar-designator)
+                      ;; No :GRAMMAR option => use *GRAMMAR* at runtime.
+                      ;; The runtime error should rarely happen since
+                      ;; the type of *GRAMMAR* is declared.
+                      `(or *grammar* (error "~@<No current grammar.~@:>"))
+                      ;; Grammar name has to be GRAMMAR-DESIGNATOR,
+                      ;; preferably of an existing grammar => check at
+                      ;; and possibly signal a full warning at compile
+                      ;; time.
+                      (progn
+                        (check-type grammar-designator grammar-designator)
+                        (coerce-to-grammar
+                         grammar-designator :if-does-not-exist #'warn)
+                        `(coerce-to-grammar ,(string grammar-designator)))))
+         (transform nil)
+         (around nil)
+         (guard t)
+         (condition t)
+         (guard-seen nil))
+
+    ;; TODO(jmoringe, 2013-01-21): redundant; see parse compiler macro
+    ;; Check EXPRESSION for errors detectable at compile time.
+    (handler-case
+        (check-expression expression)
+      (invalid-expression-error (condition)
+        (warn 'invalid-expression-warning
+              :expression (invalid-expression-expression condition))))
+
     (when options
       (dolist (option options)
         (flet ((set-transform (trans)
@@ -665,61 +1218,143 @@ Following OPTIONS can be specified:
                                (flet ((call-transform ()
                                         (funcall transform)))
                                  ,@forms)))))))))
-    `(eval-when (:load-toplevel :execute)
-       (add-rule ',symbol (make-instance 'rule
-                                         :expression ',expression
-                                         :guard-expression ',guard
-                                         :transform ,(or transform '#'identity/bounds)
-                                         :around ,around
-                                         :condition ,condition)))))
+    `(eval-when (:compile-toplevel :load-toplevel :execute)
+       ,(once-only (grammar)
+          `(progn
+             (when-let* ((cell (find-rule-cell ,grammar ',symbol :recursive nil))
+                         (rule (cell-rule cell)))
+               (dereference-rule-dependencies ,grammar rule))
+             (add-rule ',symbol
+                       (make-instance 'rule
+                                      :expression ',expression
+                                      :guard-expression ',guard
+                                      :transform ,(or transform '#'identity/bounds)
+                                      :around ,around
+                                      :condition ,condition)
+                       :grammar ,grammar))))))
 
-(defun add-rule (symbol rule)
-  "Associates RULE with the nonterminal SYMBOL. Signals an error if the
-rule is already associated with a nonterminal. If the symbol is already
-associated with a rule, the old rule is removed first."
+(declaim (type (or null rule-cell) *current-cell*))
+
+(defvar *current-cell* nil
+  "Stores the RULE-CELL instance currently being compiled.")
+
+(defun add-rule (symbol rule &key (grammar *grammar*))
+  "Associates RULE with the nonterminal SYMBOL in GRAMMAR.
+
+SYMBOL has to be a nonterminal symbol which should name the new
+rule. Note that SYMBOL itself names the rule, not (STRING SYMBOL).
+
+RULE has to be a RULE instance.
+
+If supplied, GRAMMAR has to be be a GRAMMAR instance or some other
+object designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR
+does not designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled
+
+Signals an error if the rule is already associated with a
+nonterminal. If the symbol is already associated with a rule, the old
+rule is removed first."
   ;; FIXME: This needs locking and WITHOUT-INTERRUPTS.
+  (check-type grammar (or grammar grammar-designator))
   (check-type symbol nonterminal)
-  (when (rule-symbol rule)
+
+  ;; Refuse to associate RULE to SYMBOL in GRAMMAR if it is already
+  ;; associate to some nonterminal.
+  (unless (rule-detached-p rule)
     (error "~S is already associated with the nonterminal ~S -- remove it first."
            rule (rule-symbol rule)))
-  (let* ((cell (ensure-rule-cell symbol))
-         (function (compile-rule symbol
+
+  ;; 1. Resolve GRAMMAR, if necessary
+  ;; 2. Create a rule cell for RULE in GRAMMAR
+  ;; 3. Compile RULE
+  ;; 4. Update dependencies: the added RULE may make previously
+  ;;    undefined nonterminals become defined in grammars USEing
+  ;;    GRAMMAR.
+  (let* ((grammar (coerce-to-grammar grammar))
+         (*current-cell* (ensure-rule-cell grammar symbol))
+         (function (compile-rule grammar
+                                 symbol ;; TODO
                                  (rule-expression rule)
                                  (rule-condition rule)
                                  (rule-transform rule)
                                  (rule-around rule)))
-         (trace-info (cell-trace-info cell)))
-    (set-cell-info cell function rule)
-    (setf (cell-trace-info cell) nil)
+         (trace-info (cell-trace-info *current-cell*)))
+    (set-cell-info *current-cell* function rule)
+    (setf (cell-trace-info *current-cell*) nil)
     (setf (slot-value rule '%symbol) symbol)
     (when trace-info
-      (trace-rule symbol :break (second trace-info)))
-    symbol))
+      (trace-rule symbol :grammar grammar :break (second trace-info)))
 
-(defun find-rule (symbol)
-  "Returns rule designated by SYMBOL, if any. Symbol must be a nonterminal
-symbol."
-  (check-type symbol nonterminal)
-  (let ((cell (find-rule-cell symbol)))
-    (when cell
-      (cell-rule cell))))
+    (update-rule-dependencies grammar *current-cell* symbol))
 
-(defun remove-rule (symbol &key force)
-  "Makes the nonterminal SYMBOL undefined. If the nonterminal is defined an
-already referred to by other rules, an error is signalled unless :FORCE is
-true."
+  (format t "Added ~A~%" rule) ;; TODO
+
+  ;; Return SYMBOL naming rule as handle to rule object.
+  symbol)
+
+(defun find-rule (symbol &key (grammar *grammar*) (if-does-not-exist nil))
+  "Returns the rule designated by NAME in GRAMMAR or :USEd grammars.
+
+SYMBOL has to be the nonterminal symbol naming the requested
+rule. Note that SYMBOL itself names the rule, not (STRING SYMBOL).
+
+If supplied, GRAMMAR has to be a GRAMMAR instance or some other object
+designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR does not
+designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled
+
+:IF-DOES-NOT-EXISTS determines the behavior in case SYMBOL does not
+name a rule in GRAMMAR. If NIL, NIL is returned, if a function, the
+function is called with an error condition object."
   (check-type symbol nonterminal)
+  (check-type grammar (or grammar grammar-designator))
+
+  ;; Resolve GRAMMAR, then try to find the rule cell for SYMBOL. If
+  ;; there is none, use IF-DOES-NOT-EXIST.
+  (let ((grammar (coerce-to-grammar grammar)))
+    (or (when-let ((cell (find-rule-cell grammar symbol)))
+          (cell-rule cell))
+        (etypecase if-does-not-exist
+          (null nil)
+          (function
+           (funcall if-does-not-exist
+                    (make-condition
+                     (cond
+                       ((member if-does-not-exist `(warn ,#'warn))
+                        'rule-not-found-warning)
+                       (t
+                        'rule-not-found-error))
+                     :grammar grammar :name symbol)))))))
+
+(defun remove-rule (symbol &key (grammar *grammar*) force)
+  "Makes the nonterminal SYMBOL undefined in GRAMMAR.
+
+SYMBOL has to be the nonterminal symbol. If it does not name a rule in
+GRAMMAR, nothing happens.
+
+If supplied, GRAMMAR has to be a GRAMMAR instance or some other object
+designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR does not
+designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled
+
+If SYMBOL is defined and already referred to by other rules (in
+GRAMMAR itself or grammars :USEing GRAMMAR), an error is signalled
+unless :FORCE is true."
+  (check-type symbol nonterminal)
+  (check-type grammar (or grammar grammar-designator))
+
   ;; FIXME: Lock and WITHOUT-INTERRUPTS.
-  (let* ((cell (find-rule-cell symbol))
-         (rule (cell-rule cell))
-         (trace-info (cell-trace-info cell)))
+  (let* ((grammar (coerce-to-grammar grammar))
+         (cell (find-rule-cell grammar symbol :recursive nil))
+         (rule (when cell (cell-rule cell)))
+         (trace-info (when cell (cell-trace-info cell))))
     (when cell
       (flet ((frob ()
-               (set-cell-info cell (undefined-rule-function symbol) nil)
+               (format t "Removing ~A~%" (or (cell-rule cell) cell))
+               (set-cell-info cell (undefined-rule-function grammar symbol) nil)
                (when trace-info
                  (setf (cell-trace-info cell) (list (cell-%info cell) (second trace-info))))
                (when rule
-                 (detach-rule rule))))
+                 (update-rule-dependencies grammar cell (rule-symbol rule))
+                 (dereference-rule-dependencies grammar rule)
+                 (setf (slot-value rule '%symbol) nil))))
         (cond ((and rule (cell-referents cell))
                (unless force
                  (error "Nonterminal ~S is used by other nonterminal~P:~% ~{~S~^, ~}"
@@ -730,24 +1365,139 @@ true."
                ;; There are no references to the rule at all, so
                ;; we can remove the cell.
                (unless trace-info
-                 (delete-rule-cell symbol)))))
+                 (delete-rule-cell grammar symbol)))))
       rule)))
+
+(defun change-rule (symbol expression &key (grammar *grammar*))
+  "Modifies the nonterminal SYMBOL in GRAMMAR to use EXPRESSION instead.
+
+SYMBOL has to be the nonterminal symbol. If it does not name a rule in
+GRAMMAR, an error is signaled.
+
+If supplied, GRAMMAR has to be a GRAMMAR instance or some other object
+designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR does not
+designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled."
+  (check-type grammar (or grammar grammar-designator))
+  (check-type symbol nonterminal)
+
+  ;; Resolve GRAMMAR and find the rule designated by SYMBOL. Then
+  ;; temporarily remove the rule while it is being modified.
+  (let* ((grammar (coerce-to-grammar grammar))
+         (rule (remove-rule symbol :grammar grammar :force t)))
+    (unless rule
+      (error 'rule-not-found-error :grammar grammar :name symbol))
+    (setf (rule-expression rule) expression)
+    (add-rule symbol rule :grammar grammar)))
+
+(defun dereference-rule-dependencies (grammar rule)
+  "Find cells of RULE's direct dependencies and derefence them."
+  (check-type grammar grammar)
+  (check-type rule rule)
+
+  (when-let ((cell (find-rule-cell grammar (rule-symbol rule)
+                                   :recursive nil)))
+    (dolist (dep (%rule-direct-dependencies rule))
+      (when-let ((dep-cell (find-rule-cell grammar dep)))
+        (let ((*print-level* 3)) ;; TODO
+          (format t "Dereferencing ~A~%" (or (cell-rule dep-cell) dep-cell)))
+        (dereference-rule-cell dep-cell cell)))))
+
+(defun update-rule-dependencies (grammar cell symbol)
+  "Updates dependencies of the rule (SYMBOL CELL) in GRAMMAR."
+  (check-type grammar grammar)
+  (check-type cell rule-cell)
+  (check-type symbol nonterminal)
+
+  ;; Main goals:
+  ;; 1. Update rule cell references
+  ;; 2. Collect list of rules which have to be recompiled
+  (let ((recompile '()))
+
+    ;; Check whether CELL is undefined in GRAMMAR (this happens when
+    ;; the corresponding is being removed).
+    (when (null (cdr (cell-%info cell))) ;; TODO maybe add RULE-DEFINED-P?
+      (let ((*print-level* 3)) ;; TODO
+        (format t "~A is now undefined in ~A~%" (or (cell-rule cell) cell) grammar))
+      ;; CELL is undefined. Referent cells in referent grammars have
+      ;; to be recompiled in order to create new undefined rules in
+      ;; these grammars.
+      (dolist (referent (cell-referents cell))
+        (let ((*print-level* 3)) ;; TODO
+          (format t "~2@TReferent ~A has to be recompiled~%" (or (cell-rule referent) referent)))
+        #+no (format t "~6@TRule     ~A~%" (find-rule-cell grammar d :recursive nil))
+        #+no (find-rule-cell grammar reference :recursive nil)
+        (pushnew (list referent grammar) recompile)))
+
+    ;; Find undefined rules in grammars using GRAMMAR. When these
+    ;; become defined due to (SYMBOL CELL):
+    ;; 1. Remove rule cells marking undefined rules
+    ;; 2. Recompile dependent rules
+    (dolist (referent (grammar-referents-closure grammar))
+      (format t "Checking ~A~%" referent) ;; TODO
+
+      (when-let ((cell (find-rule-cell referent symbol :recursive nil)))
+        (format t "~2@TFound rule ~A~%" cell)
+        (when (null (cdr (cell-%info cell)))
+          (format t "~2@TRule is undefined~%")
+
+          ;; TODO(jmoringe, 2012-11-20): remove-rule
+
+          (dolist (d (cell-referents cell))
+            (let ((*print-level* 3))
+             (format t "~6@TReferent ~A~%" (or (cell-rule d) d)))
+
+            (dereference-rule-cell cell d)
+            #+no (find-rule-cell referent d :recursive nil)
+            (pushnew (list d referent) recompile))
+
+          (remove-rule symbol :grammar referent))))
+
+    ;; Recompile rules discovered above.
+    (dolist (cell-and-grammar recompile)
+      (destructuring-bind (cell grammar) cell-and-grammar
+        (recompile-cell grammar cell)))))
+
+(defun recompile-cell (grammar cell)
+  (let ((*print-level* 3)) ;; TODO(jmoringe, 2013-01-27): remove
+    (format t "?Recompiling ~A~%~9@T~A~%" grammar (or (cell-rule cell) cell)))
+  (when-let ((rule (cell-rule cell)))
+    (let ((*print-level* 3))
+      (format t "!Recompiling ~A~%~9@T~A~%" grammar (or (cell-rule cell) cell)))
+    (set-cell-info cell
+                   (compile-rule grammar
+                                 (rule-symbol rule)
+                                 (rule-expression rule)
+                                 (rule-condition rule)
+                                 (rule-transform rule)
+                                 (rule-around rule))
+                   rule)))
 
 (defvar *trace-level* 0)
 
 (defvar *trace-stack* nil)
 
-(defun trace-rule (symbol &key recursive break)
-  "Turn on tracing of nonterminal SYMBOL. If RECURSIVE is true, turn
-on tracing for the whole grammar rooted at SYMBOL. If BREAK is true,
-break is entered when the rule is invoked."
+(defun trace-rule (symbol &key (grammar *grammar*) recursive break)
+  "Turn on tracing of nonterminal SYMBOL.
+
+If supplied, GRAMMAR has to be a GRAMMAR instance or some other object
+designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR does not
+designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled.
+
+If :RECURSIVE is true, turn on tracing for the whole grammar rooted at
+SYMBOL.
+
+If :BREAK is true, break is entered when the rule is invoked."
+  (check-type symbol nonterminal)
+  (check-type grammar (or grammar grammar-designator))
+
   (unless (member symbol *trace-stack* :test #'eq)
-    (let ((cell (find-rule-cell symbol)))
+    (let* ((grammar (coerce-to-grammar grammar))
+           (cell (find-rule-cell grammar symbol)))
       (unless cell
-        (error "Undefined rule: ~S" symbol))
+        (error 'rule-not-found-error :grammar grammar :name symbol))
       (when (cell-trace-info cell)
         (let ((*trace-stack* nil))
-          (untrace-rule symbol)))
+          (untrace-rule symbol :grammar grammar)))
       (let ((fun (cell-function cell))
             (rule (cell-rule cell))
             (info (cell-%info cell)))
@@ -776,18 +1526,28 @@ break is entered when the rule is invoked."
       (when recursive
         (let ((*trace-stack* (cons symbol *trace-stack*)))
           (dolist (dep (%rule-direct-dependencies (cell-rule cell)))
-            (trace-rule dep :recursive t :break break))))
+            (trace-rule dep :grammar grammar :recursive t :break break))))
       t)))
 
-(defun untrace-rule (symbol &key recursive break)
-  "Turn off tracing of nonterminal SYMBOL. If RECURSIVE is true, untraces the
-whole grammar rooted at SYMBOL. BREAK is ignored, and is provided only for
-symmetry with TRACE-RULE."
+(defun untrace-rule (symbol &key (grammar *grammar*) recursive break)
+  "Turn off tracing of nonterminal SYMBOL.
+
+If supplied, GRAMMAR has to be a GRAMMAR instance or some other object
+designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR does not
+designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled.
+
+If :RECURSIVE is true, untraces the whole grammar rooted at SYMBOL.
+
+:BREAK is ignored, and is provided only for symmetry with TRACE-RULE."
   (declare (ignore break))
+  (check-type symbol nonterminal)
+  (check-type grammar (or grammar grammar-designator))
+
   (unless (member symbol *trace-stack* :test #'eq)
-    (let ((cell (find-rule-cell symbol)))
+    (let* ((grammar (coerce-to-grammar grammar))
+           (cell (find-rule-cell grammar symbol)))
       (unless cell
-        (error "Undefined rule: ~S" symbol))
+        (error 'rule-not-found-error :grammar grammar :name symbol))
       (let ((trace-info (cell-trace-info cell)))
         (when trace-info
           (setf (cell-%info cell) (car trace-info)
@@ -795,7 +1555,7 @@ symmetry with TRACE-RULE."
         (when recursive
           (let ((*trace-stack* (cons symbol *trace-stack*)))
             (dolist (dep (%rule-direct-dependencies (cell-rule cell)))
-              (untrace-rule dep :recursive t))))))
+              (untrace-rule dep :grammar grammar :recursive t))))))
     nil))
 
 (defun rule-expression (rule)
@@ -812,41 +1572,40 @@ detached beforehand."
              name))
     (setf (slot-value rule '%expression) expression)))
 
-(defun change-rule (symbol expression)
-  "Modifies the nonterminal SYMBOL to use EXPRESSION instead. Temporarily
-removes the rule while it is being modified."
-  (let ((rule (remove-rule symbol :force t)))
-    (unless rule
-      (error "~S is not a defined rule." symbol))
-    (setf (rule-expression rule) expression)
-    (add-rule symbol rule)))
-
 (defun symbol-length (x)
   (length (symbol-name x)))
 
-(defun describe-grammar (symbol &optional (stream *standard-output*))
-  "Prints the grammar tree rooted at nonterminal SYMBOL to STREAM for human
-inspection."
+(defun describe-grammar (symbol &key (stream *standard-output*)
+                                     (grammar *grammar*))
+  "Prints the grammar tree rooted at nonterminal SYMBOL to STREAM for
+human inspection.
+
+If supplied, GRAMMAR has to be be a GRAMMAR instance or some other
+object designating a grammar (type GRAMMAR-DESIGNATOR). If GRAMMAR
+does not designate a grammar, a GRAMMAR-NOT-FOUND-ERROR is signaled"
   (check-type symbol nonterminal)
-  (let ((rule (find-rule symbol)))
+  (check-type grammar (or grammar grammar-designator))
+
+  (let* ((grammar (coerce-to-grammar grammar))
+         (rule (find-rule symbol :grammar grammar)))
     (cond ((not rule)
            (format stream "Symbol ~S is not a defined nonterminal." symbol))
           (t
-           (format stream "~&Grammar ~S:~%" symbol)
-           (multiple-value-bind (defined undefined) (rule-dependencies rule)
+           (format stream "~&Grammar ~S:~%" grammar)
+           (multiple-value-bind (defined undefined)
+               (rule-dependencies (rule-symbol rule) :grammar grammar)
              (let ((length
-                    (+ 4 (max (reduce #'max (mapcar #'symbol-length defined)
-                                      :initial-value 0)
-                              (reduce #'max (mapcar #'symbol-length undefined)
-                                      :initial-value 0)))))
-               (format stream "~3T~S~VT<- ~S~@[ : ~S~]~%"
+                     (+ 4 (reduce #'max (append defined undefined)
+                                  :initial-value 0
+                                  :key           #'symbol-length))))
+               (format stream "~3T~A~VT<- ~S~@[ : ~S~]~%"
                        symbol length (rule-expression rule)
                        (when (rule-condition rule)
                          (rule-guard-expression rule)))
                (when defined
                  (dolist (s defined)
-                   (let ((dep (find-rule s)))
-                     (format stream "~3T~S~VT<- ~S~@[ : ~S~]~%"
+                   (let ((dep (find-rule s :grammar grammar)))
+                     (format stream "~3T~A~VT<- ~S~@[ : ~S~]~%"
                             s length (rule-expression dep)
                             (when (rule-condition rule)
                               (rule-guard-expression rule))))))
@@ -856,14 +1615,10 @@ inspection."
 
 ;;; COMPILING RULES
 
-(defvar *current-rule* nil)
-
-(defun compile-rule (symbol expression condition transform around)
+(defun compile-rule (grammar symbol expression condition transform around)
   (declare (type (or boolean function) condition transform around))
-  (let* ((*current-rule* symbol)
-         ;; Must bind *CURRENT-RULE* before compiling the expression!
-         (function (compile-expression expression))
-         (rule-not-active (when condition (make-inactive-rule :name symbol))))
+  (let ((function (compile-expression grammar expression))
+        (rule-not-active (when condition (make-inactive-rule :name symbol))))
     (cond ((not condition)
            (named-lambda inactive-rule (text position end)
              (declare (ignore text position end))
@@ -915,9 +1670,6 @@ inspection."
 
 ;;; EXPRESSION COMPILER & EVALUATOR
 
-(defun invalid-expression-error (expression)
-  (error "Invalid expression: ~S" expression))
-
 (defun validate-character-range (range)
   (or
     (characterp range)
@@ -928,34 +1680,40 @@ inspection."
       (characterp (cadr range))
       (null (cddr range)))))
 
-(defun validate-expression (expression)
-  (or (typecase expression
-        ((eql character)
-         t)
-        (terminal
-         t)
-        (nonterminal
-         t)
-        (cons
-         (case (car expression)
-           ((and or)
-            (and (every #'validate-expression (cdr expression)) t))
-           ((nil)
-            nil)
-           (string
-            (and (cdr expression) (not (cddr expression))
-                 (typep (second expression) 'array-length)))
-           (character-ranges
-            (and (every #'validate-character-range (cdr expression)) t))
-           (t
-            (and (symbolp (car expression))
-                 (cdr expression) (not (cddr expression))
-                 (validate-expression (second expression))))))
-        (t
-         nil))
-      (invalid-expression-error expression)))
+(defun check-expression (expression &optional grammar)
+  (labels
+      ((rec (expression)
+         (or (typecase expression
+               ((eql character)
+                t)
+               (terminal
+                t)
+               (nonterminal
+                (if grammar
+                    (find-rule expression :grammar grammar
+                               :if-does-not-exist #'error)
+                    t))
+               (cons
+                (case (car expression)
+                  ((and or)
+                   (and (every #'rec (cdr expression)) t))
+                  ((nil)
+                   nil)
+                  (string
+                   (and (cdr expression) (not (cddr expression))
+                        (typep (second expression) 'array-length)))
+                  (character-ranges
+                   (every #'validate-character-range (rest expression)))
+                  (t
+                   (and (symbolp (car expression))
+                        (cdr expression) (not (cddr expression))
+                        (rec (second expression))))))
+               (t
+                nil))
+             (invalid-expression-error expression))))
+    (rec expression)))
 
-(defun %expression-dependencies (expression seen)
+(defun %expression-dependencies (grammar expression seen)
   (etypecase expression
     ((member character)
      seen)
@@ -964,10 +1722,10 @@ inspection."
     (nonterminal
      (if (member expression seen :test #'eq)
          seen
-         (let ((rule (find-rule expression))
+         (let ((rule (find-rule expression :grammar grammar))
                (seen (cons expression seen)))
            (if rule
-               (%expression-dependencies (rule-expression rule) seen)
+               (%expression-dependencies grammar (rule-expression rule) seen)
                seen))))
     (cons
      (case (car expression)
@@ -975,11 +1733,11 @@ inspection."
         seen)
        ((and or)
         (dolist (subexpr (cdr expression) seen)
-          (setf seen (%expression-dependencies subexpr seen))))
+          (setf seen (%expression-dependencies grammar subexpr seen))))
        ((* + ? & !)
-        (%expression-dependencies (second expression) seen))
+        (%expression-dependencies grammar (second expression) seen))
        (t
-        (%expression-dependencies (second expression) seen))))))
+        (%expression-dependencies grammar (second expression) seen))))))
 
 (defun %expression-direct-dependencies (expression seen)
   (etypecase expression
@@ -1001,7 +1759,7 @@ inspection."
        (t
         (%expression-direct-dependencies (second expression) seen))))))
 
-(defun eval-expression (expression text position end)
+(defun eval-expression (grammar expression text position end)
   (typecase expression
     ((eql character)
      (eval-character text position end))
@@ -1010,37 +1768,46 @@ inspection."
          (eval-terminal (string (second expression)) text position end nil)
          (eval-terminal (string expression) text position end t)))
     (nonterminal
-     (eval-nonterminal expression text position end))
+     (eval-nonterminal grammar expression text position end))
     (cons
      (case (car expression)
        (string
-        (eval-string expression text position end))
+        ;; TODO(jmoringe, 2013-01-27): hack until EXPRESSION-CASE gets integrated
+        (if (integerp (second expression))
+            (eval-string expression text position end)
+            (invalid-expression-error expression)))
        (and
-        (eval-sequence expression text position end))
+        (eval-sequence grammar expression text position end))
        (or
-        (eval-ordered-choise expression text position end))
+        (eval-ordered-choise grammar expression text position end))
        (not
-        (eval-negation expression text position end))
+        ;; TODO(jmoringe, 2013-01-27): hack until EXPRESSION-CASE gets integrated
+        (if (length= 2 expression)
+            (eval-negation grammar expression text position end)
+            (invalid-expression-error expression)))
        (*
-        (eval-greedy-repetition expression text position end))
+        (eval-greedy-repetition grammar expression text position end))
        (+
-        (eval-greedy-positive-repetition expression text position end))
+        (eval-greedy-positive-repetition grammar expression text position end))
        (?
-        (eval-optional expression text position end))
+        (eval-optional grammar expression text position end))
        (&
-        (eval-followed-by expression text position end))
+        (eval-followed-by grammar expression text position end))
        (!
-        (eval-not-followed-by expression text position end))
+        (eval-not-followed-by grammar expression text position end))
        (character-ranges
-        (eval-character-ranges expression text position end))
+        ;; TODO(jmoringe, 2013-01-27): hack until EXPRESSION-CASE gets integrated
+        (if (every #'validate-character-range (rest expression))
+            (eval-character-ranges grammar expression text position end)
+            (invalid-expression-error expression)))
        (t
         (if (symbolp (car expression))
-            (eval-semantic-predicate expression text position end)
+            (eval-semantic-predicate grammar expression text position end)
             (invalid-expression-error expression)))))
     (t
      (invalid-expression-error expression))))
 
-(defun compile-expression (expression)
+(defun compile-expression (grammar expression)
   (etypecase expression
     ((eql character)
      (compile-character))
@@ -1049,32 +1816,32 @@ inspection."
          (compile-terminal (string (second expression)) nil)
          (compile-terminal (string expression) t)))
     (nonterminal
-     (compile-nonterminal expression))
+     (compile-nonterminal grammar expression))
     (cons
      (case (car expression)
        (string
         (compile-string expression))
        (and
-        (compile-sequence expression))
+        (compile-sequence grammar expression))
        (or
-        (compile-ordered-choise expression))
+        (compile-ordered-choise grammar expression))
        (not
-        (compile-negation expression))
+        (compile-negation grammar expression))
        (*
-        (compile-greedy-repetition expression))
+        (compile-greedy-repetition grammar expression))
        (+
-        (compile-greedy-positive-repetition expression))
+        (compile-greedy-positive-repetition grammar expression))
        (?
-        (compile-optional expression))
+        (compile-optional grammar expression))
        (&
-        (compile-followed-by expression))
+        (compile-followed-by grammar expression))
        (!
-        (compile-not-followed-by expression))
+        (compile-not-followed-by grammar expression))
        (character-ranges
-        (compile-character-ranges expression))
+        (compile-character-ranges grammar expression))
        (t
         (if (symbolp (car expression))
-            (compile-semantic-predicate expression)
+            (compile-semantic-predicate grammar expression)
             (invalid-expression-error expression)))))
     (t
      (invalid-expression-error expression))))
@@ -1145,14 +1912,17 @@ inspection."
 
 (defparameter *eval-nonterminals* nil)
 
-(defun eval-nonterminal (symbol text position end)
+(defun eval-nonterminal (grammar symbol text position end)
   (if *eval-nonterminals*
-      (eval-expression (rule-expression (find-rule symbol)) text position end)
-      (funcall (cell-function (ensure-rule-cell symbol)) text position end)))
+      (eval-expression
+       grammar (rule-expression (find-rule symbol :grammar grammar)) text position end)
+      (funcall (cell-function (ensure-rule-cell grammar symbol)) text position end)))
 
-(defun compile-nonterminal (symbol)
-  (let ((cell (reference-rule-cell symbol *current-rule*)))
+(defun compile-nonterminal (grammar symbol)
+  (let ((cell (ensure-rule-cell grammar symbol)))
     (declare (rule-cell cell))
+    (unless (eq cell *current-cell*)
+      (reference-rule-cell cell *current-cell*))
     (named-lambda compile-nonterminal (text position end)
       (funcall (cell-function cell) text position end))))
 
@@ -1161,14 +1931,14 @@ inspection."
 ;;; FIXME: It might be better if we actually chained the closures
 ;;; here, instead of looping over them -- benchmark first, though.
 
-(defun eval-sequence (expression text position end)
+(defun eval-sequence (grammar expression text position end)
   (with-expression (expression (and &rest subexprs))
     (let (results)
       (dolist (expr subexprs
                (make-result
                 :position position
                 :production (mapcar #'result-production (nreverse results))))
-        (let ((result (eval-expression expr text position end)))
+        (let ((result (eval-expression grammar expr text position end)))
           (if (error-result-p result)
               (return (make-failed-parse
                        :expression expression
@@ -1177,9 +1947,11 @@ inspection."
               (setf position (result-position result)))
           (push result results))))))
 
-(defun compile-sequence (expression)
+(defun compile-sequence (grammar expression)
   (with-expression (expression (and &rest subexprs))
-    (let ((functions (mapcar #'compile-expression subexprs)))
+    (let ((functions (mapcar (lambda (subexpr)
+                               (compile-expression grammar subexpr))
+                             subexprs)))
       (named-lambda compiled-sequence (text position end)
           (let (results)
             (dolist (fun functions
@@ -1197,7 +1969,7 @@ inspection."
 
 ;;; Ordered choises
 
-(defun eval-ordered-choise (expression text position end)
+(defun eval-ordered-choise (grammar expression text position end)
   (with-expression (expression (or &rest subexprs))
     (let (last-error)
       (dolist (expr subexprs
@@ -1207,7 +1979,7 @@ inspection."
                               (failed-parse-position last-error)
                               position)
                 :detail last-error))
-        (let ((result (eval-expression expr text position end)))
+        (let ((result (eval-expression grammar expr text position end)))
           (if (error-result-p result)
               (when (or (and (not last-error)
                              (or (inactive-rule-p result)
@@ -1220,7 +1992,7 @@ inspection."
                 (setf last-error result))
               (return result)))))))
 
-(defun compile-ordered-choise (expression)
+(defun compile-ordered-choise (grammar expression)
   (with-expression (expression (or &rest subexprs))
     (let ((type :characters)
           (canonized nil))
@@ -1277,7 +2049,9 @@ inspection."
                                   :production choise))))))))
         (:general
          ;; In the general case, compile subexpressions and call.
-         (let ((functions (mapcar #'compile-expression subexprs)))
+         (let ((functions (mapcar (lambda (subexpr)
+                                    (compile-expression grammar subexpr))
+                                  subexprs)))
              (named-lambda compiled-ordered-choise (text position end)
                (let (last-error)
                  (dolist (fun functions
@@ -1313,27 +2087,27 @@ inspection."
        :expression expr
        :position position)))
 
-(defun eval-negation (expression text position end)
+(defun eval-negation (grammar expression text position end)
   (with-expression (expression (not subexpr))
     (flet ((eval-sub (text position end)
-             (eval-expression subexpr text position end)))
+             (eval-expression grammar subexpr text position end)))
       (declare (dynamic-extent #'eval-sub))
       (exec-negation #'eval-sub expression text position end))))
 
-(defun compile-negation (expression)
+(defun compile-negation (grammar expression)
   (with-expression (expression (not subexpr))
-    (let ((sub (compile-expression subexpr)))
+    (let ((sub (compile-expression grammar subexpr)))
       (named-lambda compiled-negation (text position end)
         (exec-negation sub expression text position end)))))
 
 ;;; Greedy repetitions
 
-(defun eval-greedy-repetition (expression text position end)
-  (funcall (compile-greedy-repetition expression) text position end))
+(defun eval-greedy-repetition (grammar expression text position end)
+  (funcall (compile-greedy-repetition grammar expression) text position end))
 
-(defun compile-greedy-repetition (expression)
+(defun compile-greedy-repetition (grammar expression)
   (with-expression (expression (* subexpr))
-    (let ((function (compile-expression subexpr)))
+    (let ((function (compile-expression grammar subexpr)))
       (named-lambda compiled-greedy-repetition (text position end)
         (let ((results
                (loop for result = (funcall function text position end)
@@ -1346,13 +2120,13 @@ inspection."
 
 ;;; Greedy positive repetitions
 
-(defun eval-greedy-positive-repetition (expression text position end)
-  (funcall (compile-greedy-positive-repetition expression)
+(defun eval-greedy-positive-repetition (grammar expression text position end)
+  (funcall (compile-greedy-positive-repetition grammar expression)
            text position end))
 
-(defun compile-greedy-positive-repetition (expression)
+(defun compile-greedy-positive-repetition (grammar expression)
   (with-expression (expression (+ subexpr))
-    (let ((function (compile-expression subexpr)))
+    (let ((function (compile-expression grammar subexpr)))
       (named-lambda compiled-greedy-positive-repetition (text position end)
         (let* ((last nil)
                (results
@@ -1371,16 +2145,16 @@ inspection."
 
 ;;; Optionals
 
-(defun eval-optional (expression text position end)
+(defun eval-optional (grammar expression text position end)
   (with-expression (expression (? subexpr))
-    (let ((result (eval-expression subexpr text position end)))
+    (let ((result (eval-expression grammar subexpr text position end)))
       (if (error-result-p result)
           (make-result :position position)
           result))))
 
-(defun compile-optional (expression)
+(defun compile-optional (grammar expression)
   (with-expression (expression (? subexpr))
-    (let ((function (compile-expression subexpr)))
+    (let ((function (compile-expression grammar subexpr)))
       (named-lambda compiled-optional (text position end)
         (let ((result (funcall function text position end)))
           (if (error-result-p result)
@@ -1389,9 +2163,9 @@ inspection."
 
 ;;; Followed-by's
 
-(defun eval-followed-by (expression text position end)
+(defun eval-followed-by (grammar expression text position end)
   (with-expression (expression (& subexpr))
-    (let ((result (eval-expression subexpr text position end)))
+    (let ((result (eval-expression grammar subexpr text position end)))
       (if (error-result-p result)
           (make-failed-parse
            :position position
@@ -1401,9 +2175,9 @@ inspection."
            :position position
            :production (result-production result))))))
 
-(defun compile-followed-by (expression)
+(defun compile-followed-by (grammar expression)
   (with-expression (expression (& subexpr))
-    (let ((function (compile-expression subexpr)))
+    (let ((function (compile-expression grammar subexpr)))
       (named-lambda compiled-followed-by (text position end)
         (let ((result (funcall function text position end)))
           (if (error-result-p result)
@@ -1417,9 +2191,9 @@ inspection."
 
 ;;; Not followed-by's
 
-(defun eval-not-followed-by (expression text position end)
+(defun eval-not-followed-by (grammar expression text position end)
   (with-expression (expression (! subexpr))
-    (let ((result (eval-expression subexpr text position end)))
+    (let ((result (eval-expression grammar subexpr text position end)))
       (if (error-result-p result)
           (make-result
            :position position)
@@ -1427,9 +2201,9 @@ inspection."
            :expression expression
            :position position)))))
 
-(defun compile-not-followed-by (expression)
+(defun compile-not-followed-by (grammar expression)
   (with-expression (expression (! subexpr))
-    (let ((function (compile-expression subexpr)))
+    (let ((function (compile-expression grammar subexpr)))
       (named-lambda compiled-not-followed-by (text position end)
         (let ((result (funcall function text position end)))
           (if (error-result-p result)
@@ -1441,9 +2215,9 @@ inspection."
 
 ;;; Semantic predicates
 
-(defun eval-semantic-predicate (expression text position end)
+(defun eval-semantic-predicate (grammar expression text position end)
   (with-expression (expression (t subexpr))
-    (let ((result (eval-expression subexpr text position end)))
+    (let ((result (eval-expression grammar subexpr text position end)))
       (if (error-result-p result)
           (make-failed-parse
            :position position
@@ -1456,9 +2230,9 @@ inspection."
                  :position position
                  :expression expression)))))))
 
-(defun compile-semantic-predicate (expression)
+(defun compile-semantic-predicate (grammar expression)
   (with-expression (expression (t subexpr))
-    (let* ((function (compile-expression subexpr))
+    (let* ((function (compile-expression grammar subexpr))
            (predicate (car expression))
            ;; KLUDGE: Calling via a variable symbol can be slow, and if we
            ;; grab the SYMBOL-FUNCTION here we will not see redefinitions.
@@ -1482,7 +2256,8 @@ inspection."
 
 ;;; Character ranges
 
-(defun exec-character-ranges (expression ranges text position end)
+(defun exec-character-ranges (grammar expression ranges text position end)
+  (declare (ignore grammar))
   (flet ((oops ()
            (make-failed-parse
             :expression expression
@@ -1501,14 +2276,16 @@ inspection."
              (oops)))
         (oops))))
 
-(defun eval-character-ranges (expression text position end)
+(defun eval-character-ranges (grammar expression text position end)
   (with-expression (expression (character-ranges &rest ranges))
-    (exec-character-ranges expression ranges text position end)))
+    (exec-character-ranges grammar expression ranges text position end)))
 
-(defun compile-character-ranges (expression)
+(defun compile-character-ranges (grammar expression)
   (with-expression (expression (character-ranges &rest ranges))
     (named-lambda compiled-character-ranges (text position end)
-      (exec-character-ranges expression ranges text position end))))
+      (exec-character-ranges grammar expression ranges text position end))))
+
+;;; Hints for SLIME
 
 (defvar *indentation-hint-table* nil)
 

--- a/example-sexp-xml.lisp
+++ b/example-sexp-xml.lisp
@@ -1,0 +1,48 @@
+;;;; Esrap example: mix pseudo-XML and a simple S-expression grammar
+
+(require :esrap)
+
+(defpackage :xml-sexp-grammar
+  (:use :cl :esrap))
+
+(in-package :xml-sexp-grammar)
+
+(defgrammar #:xml
+  (:use #:sexp)
+  (:documentation
+   "Accepts pseudo-XML mixed with S-expressions as defined in the SEXP
+grammar."))
+(in-grammar #:xml)
+
+(defrule open-tag (and "<" (and (! "sexp") (+ (not ">"))) ">")
+  (:destructure (open name close)
+    (declare (ignore open close))
+    (intern (text name))))
+
+(defrule close-tag (and "</" (and (! "sexp") (+ (not ">"))) ">")
+  (:destructure (open name close)
+    (declare (ignore open close))
+    (intern (text name))))
+
+(defrule sexp-element (and "<sexp>" sexp "</sexp>")
+  (:function second))
+
+(defrule term-element (and open-tag
+                           (and (not "<") (* (and (! close-tag) character)))
+                           close-tag)
+  (:destructure (open innertext close)
+    (assert (string= open close))
+    (list open (text innertext))))
+
+(defrule element (and open-tag
+                      (+ (or sexp-element term-element element))
+                      close-tag)
+  (:destructure (open content close)
+    (assert (string= open close))
+    (cons open content)))
+
+(defrule xml (or sexp-element element term-element))
+
+;;;; Try these
+
+(parse 'xml "<test><i>text</i><sexp>(a 2 3 foo </sexp> \"bla</sexp><foo><foo/>)\")</sexp></test>")

--- a/example-sexp-xml.lisp
+++ b/example-sexp-xml.lisp
@@ -3,7 +3,7 @@
 (require :esrap)
 
 (defpackage :xml-sexp-grammar
-  (:use :cl :esrap))
+  (:use :cl :esrap :sexp-grammar))
 
 (in-package :xml-sexp-grammar)
 

--- a/example-sexp.lisp
+++ b/example-sexp.lisp
@@ -3,7 +3,9 @@
 (require :esrap)
 
 (defpackage :sexp-grammar
-  (:use :cl :esrap))
+  (:use :cl :esrap)
+  (:export
+   :sexp))
 
 (in-package :sexp-grammar)
 
@@ -72,22 +74,22 @@
 #+no (let ((* :use-magic))
   (parse '#:sexp 'sexp "foobar"))
 
-(describe-grammar '#:sexp 'sexp)
+(describe-grammar 'sexp)
 
-(trace-rule '#:sexp 'sexp :recursive t)
+(trace-rule 'sexp :recursive t)
 
 (parse 'sexp "(foo bar 1 quux)")
 
-(untrace-rule '#:sexp 'sexp :recursive t)
+(untrace-rule 'sexp :recursive t)
 
-(defparameter *orig* (rule-expression (find-rule '#:sexp 'sexp)))
+(defparameter *orig* (rule-expression (find-rule 'sexp)))
 
-(change-rule '#:sexp 'sexp '(and (? whitespace) (or list symbol)))
+(change-rule 'sexp '(and (? whitespace) (or list symbol)))
 
 (parse 'sexp "(foo bar quux)")
 
 (parse 'sexp "(foo bar 1 quux)" :junk-allowed t)
 
-(change-rule '#:sexp 'sexp *orig*)
+(change-rule 'sexp *orig*)
 
 (parse 'sexp "(foo bar 1 quux)" :junk-allowed t)

--- a/example-sexp.lisp
+++ b/example-sexp.lisp
@@ -7,23 +7,19 @@
 
 (in-package :sexp-grammar)
 
-;;; A semantic predicate for filtering out double quotes.
-
-(defun not-doublequote (char)
-  (not (eql #\" char)))
-
-(defun not-integer (string)
-  (when (find-if-not #'digit-char-p string)
+(defun not-integer (partial-result)
+  (when (find-if-not #'digit-char-p (text partial-result))
     t))
+
+(defgrammar #:sexp
+  (:documentation
+   "A simple grammar for S-expressions."))
+(in-grammar #:sexp)
 
 ;;; Utility rules.
 
 (defrule whitespace (+ (or #\space #\tab #\newline))
   (:constant nil))
-
-(defrule alphanumeric (alphanumericp character))
-
-(defrule string-char (or (not-doublequote character) (and #\\ #\")))
 
 ;;; Here we go: an S-expression is either a list or an atom, with possibly leading whitespace.
 
@@ -41,18 +37,18 @@
     (declare (ignore p1 p2 w))
     (cons car cdr)))
 
-(defrule atom (or string integer symbol))
-
-(defrule string (and #\" (* string-char) #\")
+(defrule string (and #\" (* (not #\")) #\")
   (:destructure (q1 string q2)
     (declare (ignore q1 q2))
     (text string)))
+
+(defrule atom (or string integer symbol))
 
 (defrule integer (+ (or "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"))
   (:lambda (list)
     (parse-integer (text list) :radix 10)))
 
-(defrule symbol (not-integer (+ alphanumeric))
+(defrule symbol (not-integer (+ (or (alphanumericp character) #\< #\> #\/ #\- #\_ #\?)))
   ;; NOT-INTEGER is not strictly needed because ATOM considers INTEGER before
   ;; a STRING, we know can accept all sequences of alphanumerics -- we already
   ;; know it isn't an integer.
@@ -60,6 +56,8 @@
     (intern (text list))))
 
 ;;;; Try these
+
+(find-grammar '#:sexp)
 
 (parse 'sexp "FOO123")
 
@@ -71,25 +69,25 @@
 
 (parse 'sexp "foobar")
 
-(let ((* :use-magic))
-  (parse 'sexp "foobar"))
+#+no (let ((* :use-magic))
+  (parse '#:sexp 'sexp "foobar"))
 
-(describe-grammar 'sexp)
+(describe-grammar '#:sexp 'sexp)
 
-(trace-rule 'sexp :recursive t)
+(trace-rule '#:sexp 'sexp :recursive t)
 
 (parse 'sexp "(foo bar 1 quux)")
 
-(untrace-rule 'sexp :recursive t)
+(untrace-rule '#:sexp 'sexp :recursive t)
 
-(defparameter *orig* (rule-expression (find-rule 'sexp)))
+(defparameter *orig* (rule-expression (find-rule '#:sexp 'sexp)))
 
-(change-rule 'sexp '(and (? whitespace) (or list symbol)))
+(change-rule '#:sexp 'sexp '(and (? whitespace) (or list symbol)))
 
 (parse 'sexp "(foo bar quux)")
 
 (parse 'sexp "(foo bar 1 quux)" :junk-allowed t)
 
-(change-rule 'sexp *orig*)
+(change-rule '#:sexp 'sexp *orig*)
 
 (parse 'sexp "(foo bar 1 quux)" :junk-allowed t)

--- a/example-symbol-table.lisp
+++ b/example-symbol-table.lisp
@@ -29,7 +29,8 @@
            name))
   (setf (gethash name (symbol-table-%table table)) new-value))
 
-
+(defgrammar #:symbol-table)
+(in-grammar #:symbol-table)
 
 (defrule whitespace
     (+ (or #\Space #\Tab #\Newline))

--- a/tests.lisp
+++ b/tests.lisp
@@ -322,8 +322,6 @@ safe."
   (signals rule-not-found-error (parse 'd "bb" :grammar '#:fez))
 
   ;; After redefinition of B in BAZ:
-  (format t "Defining ~S in ~A~%"
-          'b  '#:baz)
   (eval '(defrule (b :grammar #:baz) (+ "b")))
 
   (signals esrap-error (parse 'd "aa" :grammar '#:fez) "aa")

--- a/tests.lisp
+++ b/tests.lisp
@@ -28,7 +28,371 @@
 (def-suite esrap)
 (in-suite esrap)
 
-;;;; A few semantic predicates
+;;; Some helper macros
+
+(defmacro with-clean-outer-compilation-unit (&body body)
+  ;; Keep outer compilation-unit report clean.
+  `(let ((*error-output*    (make-broadcast-stream)))
+     (with-compilation-unit (:override t)
+       ,@body)))
+
+(defmacro ignoring-compile-time-warnings ((condition) &body body)
+  `(funcall
+    (with-clean-outer-compilation-unit
+        (handler-bind
+            ((,condition #'muffle-warning))
+          (compile nil '(lambda () ,@body))))))
+
+(defmacro compilation-signals (condition &body body)
+  `(with-clean-outer-compilation-unit
+       (signals ,condition
+         (compile nil '(lambda () ,@body)))))
+
+(test defgrammar.smoke
+  (defgrammar #:defgrammar.smoke
+    (:documentation "test"))
+
+  (is (equal (grammar-name (find-grammar '#:defgrammar.smoke))
+             "DEFGRAMMAR.SMOKE"))
+  (is (equal (documentation (find-grammar '#:defgrammar.smoke) t)
+             "test")))
+
+(test defgrammar.use-non-existent-grammar
+  "Test :USEing a non-existent grammar in DEFGRAMMAR."
+  ;; We should see a warning at compile time and an error at
+  ;; runtime. Check both independently.
+
+  ;; Compile to check full warning at compile time.
+  (compilation-signals grammar-not-found-warning
+    (defgrammar #:baz (:use #:does-not-exist)))
+
+  ;; Compile, ignoring compile time warnings, then check runtime
+  ;; error.
+  (signals grammar-not-found-error
+    (ignoring-compile-time-warnings (grammar-not-found-warning)
+      (defgrammar #:baz (:use #:does-not-exist)))))
+
+(test in-grammar.non-existent-grammar
+  "Test IN-GRAMMAR on non-existent grammar."
+  ;; See defgrammar.use-non-existent.
+  (compilation-signals grammar-not-found-warning
+    (in-grammar #:does-not-exist))
+
+  (signals grammar-not-found-error
+    (ignoring-compile-time-warnings (grammar-not-found-warning)
+      (in-grammar #:does-not-exist))))
+
+(test find-grammar.non-existent
+  "Test FIND-GRAMMAR on non-existent grammar."
+  (is (null (find-grammar '#:does-not-exist :if-does-not-exist nil)))
+  (signals grammar-not-found-warning
+    (find-grammar '#:does-not-exist :if-does-not-exist #'warn))
+  (signals grammar-not-found-error
+    (find-grammar '#:does-not-exist :if-does-not-exist #'error)))
+
+(test defrule.non-existent-grammar
+  "Test DEFRULE with non-existent grammar."
+  ;; See defgrammar.use-non-existent.
+  (compilation-signals grammar-not-found-warning
+    (defrule (foo :grammar #:does-not-exist) "foo"))
+
+  (signals grammar-not-found-error
+    (ignoring-compile-time-warnings (grammar-not-found-warning)
+      (defrule (foo :grammar #:does-not-exist) "foo"))))
+
+(test defrule.check-expression
+  "Test expression checking in DEFRULE."
+  ;; Test conditions signaled by DEFRULE at compile time.
+  (compilation-signals invalid-expression-warning
+    (defrule foo '(~ 1)))
+  (compilation-signals invalid-expression-warning
+    (defrule (foo :grammar #:test) '(~ 1)))
+
+  ;; Test conditions signaled by DEFRULE at runtime.
+  (macrolet ((is-invalid-expr (&body body)
+               `(signals invalid-expression-error
+                  (ignoring-compile-time-warnings (invalid-expression-warning)
+                    ,@body))))
+    (is-invalid-expr (defrule foo '(~ 1)))
+    (is-invalid-expr (defrule foo '(string)))
+    (is-invalid-expr (defrule foo '(character-ranges 1)))
+    (is-invalid-expr (defrule foo '(character-ranges (#\a))))
+    (is-invalid-expr (defrule foo '(character-ranges (#\a #\b #\c))))
+    (is-invalid-expr (defrule foo '(and (string))))
+    (is-invalid-expr (defrule foo '(not)))))
+
+;;; FIND-RULE.{ARGUMENT-CHECKING,NON-EXISTENT}
+
+(defgrammar #:find-rule)
+(defrule (foo :grammar #:find-rule) #\a)
+
+(test find-rule.smoke
+  (is (not (null (find-rule 'foo :grammar '#:find-rule))))
+  (is (null (find-rule :foo :grammar '#:find-rule)))
+  (is (null (find-rule '#:foo :grammar '#:find-rule))))
+
+(test find-rule.argument-checking
+  "Test argument checking in FIND-RULE."
+  (signals grammar-not-found-error
+    (find-rule 'does-not-matter :grammar '#:no-such-grammar)))
+
+(test find-rule.non-existent
+  "Test FIND-RULE with non-existent rule."
+  (is (null (find-rule '#:does-not-exist :grammar '#:find-rule
+                       :if-does-not-exist nil)))
+  (signals rule-not-found-warning
+    (find-rule '#:does-not-exist :grammar '#:find-rule
+               :if-does-not-exist #'warn))
+  (signals rule-not-found-error
+    (find-rule '#:does-not-exist :grammar '#:find-rule
+               :if-does-not-exist #'error)))
+
+;;; REMOVE-RULE.ARGUMENT-CHECKING
+
+(defgrammar #:remove-rule.argument-checking)
+
+(test remove-rule.argument-checking
+  "Test argument checking in REMOVE-RULE."
+  (signals grammar-not-found-error
+    (remove-rule 'does-not-matter :grammar '#:no-such-grammar))
+  (is (null (remove-rule 'no-such-rule :grammar '#:remove-rule.argument-checking))))
+
+;;; REMOVE-RULE.USED.{ERROR,CORRECT-ORDER,redefinition}
+
+;; We define three rules across two grammars:
+;; Grammar FOO:         B -uses-> A
+;; Grammar BAR: C -uses-^
+;; Then try remove rules A and B in different ways.
+(defgrammar #:remove-rule.used.foo)
+(defgrammar #:remove-rule.used.bar
+  (:use #:remove-rule.used.foo))
+
+(defun define-rules-for-used-test ()
+  (defrule (a :grammar #:remove-rule.used.foo) (+ "a"))
+  (defrule (b :grammar #:remove-rule.used.foo) a)
+  (defrule (c :grammar #:remove-rule.used.bar) b))
+
+(test remove-rule.used.error
+  "Test error signaling when attempting to remove rules which are used
+by other rules."
+  (define-rules-for-used-test)
+
+  ;; A in FOO is used by B in FOO.
+  (signals error (remove-rule 'a :grammar '#:remove-rule.used.foo))
+  ;; B in FOO is used by C in BAR.
+  (signals error (remove-rule 'b :grammar '#:remove-rule.used.foo)))
+
+(test remove-rule.used.correct-order
+  "Test removing rules with dependencies in a safe order."
+  (define-rules-for-used-test)
+
+  ;; This order should work.
+  (remove-rule 'c :grammar '#:remove-rule.used.bar)
+  (remove-rule 'b :grammar '#:remove-rule.used.foo)
+  (remove-rule 'a :grammar '#:remove-rule.used.foo))
+
+(test remove-rule.used.redefinition
+  "Test removing rules after redefinition which makes the removal
+safe."
+  (define-rules-for-used-test)
+
+  ;; Redefine B in FOO to not use A in FOO, then delete A in FOO.
+  (defrule (b :grammar #:remove-rule.used.foo) (or))
+  (remove-rule 'a :grammar '#:remove-rule.used.foo)
+
+  ;; Redefine C in BAR to not use B in FOO, then delete B in FOO.
+  (defrule (c :grammar #:remove-rule.used.bar) (or))
+  (remove-rule 'b :grammar '#:remove-rule.used.foo)
+
+  ;; C in BAR can be removed without redefinition.
+  (remove-rule 'c :grammar '#:remove-rule.used.bar))
+
+;;; RULE-DEPENDENCIES.{SMOKE,CONDITIONS}
+
+(defgrammar #:rule-dependencies)
+(defrule (a :grammar #:rule-dependencies)
+    #\a)
+(defrule (b :grammar #:rule-dependencies)
+    (or a #\b))
+(defrule (c :grammar #:rule-dependencies)
+    (or b #\c))
+(defrule (d :grammar #:rule-dependencies)
+    (or a b c))
+
+(test rule-dependencies.smoke
+  "Smoke test for RULE-DEPENDENCIES."
+  ;; Test default grammar.
+  (let ((*grammar* (find-grammar '#:rule-dependencies)))
+    (is (set-equal (rule-dependencies 'd) '(a b c))))
+
+  ;; Test explicitly specified grammar.
+  (macrolet
+      ((has-dependencies (rule grammar &rest expected)
+         `(is (set-equal (rule-dependencies ',rule :grammar ',grammar)
+                         '(,@expected)))))
+    (has-dependencies d #:rule-dependencies a b c)
+    (has-dependencies c #:rule-dependencies a b)
+    (has-dependencies b #:rule-dependencies a)
+    (has-dependencies a #:rule-dependencies)))
+
+(test rule-dependencies.conditions
+  "Test conditions signaled by RULE-DEPENDENCIES."
+  (signals rule-not-found-error
+    (rule-dependencies 'no-such-rule))
+  (signals grammar-not-found-error
+    (rule-dependencies 'does-not-matter :grammar '#:no-such-grammar)))
+
+;;; CHANGE-RULE.{ARGUMENT-CHECKING,SMOKE}
+
+(defgrammar #:change-rule)
+(defrule (foo :grammar #:change-rule)
+    bar)
+
+(test change-rule.argument-checking
+  "Test argument checking in CHANGE-RULE."
+  (signals grammar-not-found-error
+    (change-rule 'does-not-matter 'baz :grammar '#:no-such-grammar))
+  (signals rule-not-found-error
+    (change-rule 'no-such-rule 'baz :grammar '#:change-rule)))
+
+(test change-rule.smoke
+  "Smoke test for CHANGE-RULE."
+  ;; TODO(jmoringe, 2013-01-27): should RULE-EXPRESSION accept rule and grammar designators?
+  (is (equal (rule-expression (find-rule 'foo :grammar '#:change-rule)) 'bar))
+  (change-rule 'foo 'baz :grammar '#:change-rule)
+  (is (equal (rule-expression (find-rule 'foo :grammar '#:change-rule)) 'baz)))
+
+;;; GRAMMAR-INCLUSION.SMOKE
+
+;; We define two grammars, FOO and BAR, and make sure that BAR can use
+;; rules defined in FOO.
+(defgrammar #:foo)
+
+(defrule (a :grammar #:foo)
+    (+ "a"))
+
+(defgrammar #:bar
+  (:use #:foo))
+
+(defrule (b :grammar #:bar)
+    (or a (+ "b"))
+  (:text t))
+
+(test grammar-inclusion.smoke
+  "Smoke test for parsing with grammars which have dependencies."
+  (is (string= (parse 'b "aa" :grammar '#:bar) "aa"))
+  (is (string= (parse 'b "bb" :grammar '#:bar) "bb")))
+
+;; We define a minimal grammar now, to avoid compile-time warning. At
+;; runtime, we delete everything and set it up again. This is required
+;; for repeated execution of the test.
+(defgrammar #:fez)
+(defrule (d :grammar #:fez) (or))
+
+(test grammar-inclusion.redefinition-accross-grammars
+  "Test grammar redefinition for grammars with dependencies."
+  ;; We define two grammars, BAZ and FEZ, and make sure that FEZ can use
+  ;; rules defined in BAZ. Grammar FEZ uses rules A and B from BAZ. Rule
+  ;; B is undefined in both grammars at first and defined in BAZ later.
+  (eval '(progn
+          (defrule (d :grammar #:fez) (or))
+
+          (defgrammar #:baz)
+          (remove-rule 'b :grammar '#:baz)
+          (defrule (a :grammar #:baz)
+              (+ "a"))
+
+          (defgrammar #:fez (:use #:baz))
+          (defrule (d :grammar #:fez)
+              (or a (+ "c") b)
+            (:text t))))
+
+  ;; Before redefinition:
+  (is (string= (parse 'd "aa" :grammar '#:fez) "aa"))
+  (signals rule-not-found-error (parse 'd "AA" :grammar '#:fez))
+  (is (string= (parse 'd "cc" :grammar '#:fez) "cc"))
+  (signals rule-not-found-error (parse 'd "bb" :grammar '#:fez))
+
+  ;; After redefinition of A in BAZ:
+  (eval '(defrule (a :grammar #:baz) (+ "A")))
+
+  (signals rule-not-found-error (parse 'd "aa" :grammar '#:fez) "aa")
+  (is (string= (parse 'd "AA" :grammar '#:fez) "AA"))
+  (is (string= (parse 'd "cc" :grammar '#:fez) "cc"))
+  (signals rule-not-found-error (parse 'd "bb" :grammar '#:fez))
+
+  ;; After redefinition of B in BAZ:
+  (format t "Defining ~S in ~A~%"
+          'b  '#:baz)
+  (eval '(defrule (b :grammar #:baz) (+ "b")))
+
+  (signals esrap-error (parse 'd "aa" :grammar '#:fez) "aa")
+  (is (string= (parse 'd "AA" :grammar '#:fez) "AA"))
+  (is (string= (parse 'd "cc" :grammar '#:fez) "cc"))
+  (is (string= (parse 'd "bb" :grammar '#:fez) "bb")))
+
+;;; GRAMMAR-INCLUSION.REDEFINITION-WITH-ADDED-USE
+
+(defgrammar #:grammar-inclusion.redefinition-with-added-use.foo)
+(defrule (a :grammar #:grammar-inclusion.redefinition-with-added-use.foo)
+    "a")
+(defgrammar #:grammar-inclusion.redefinition-with-added-use.bar)
+(defrule (b :grammar #:grammar-inclusion.redefinition-with-added-use.bar)
+    a)
+
+(test grammar-inclusion.redefinition-with-added-use
+  "Test redefining a grammar to use another upstream grammar."
+  (signals rule-not-found-error
+    (parse 'b "a" :grammar '#:grammar-inclusion.redefinition-with-added-use.bar))
+
+  (defgrammar #:grammar-inclusion.redefinition-with-added-use.bar
+    (:use #:grammar-inclusion.redefinition-with-added-use.foo))
+
+  (is (string= (parse 'b "a" :grammar '#:grammar-inclusion.redefinition-with-added-use.bar) "a")))
+
+;;; GRAMMAR-INCLUSION.REDEFINITION-WITH-REMOVED-USE
+
+(defgrammar #:grammar-inclusion.redefinition-with-removed-use.foo)
+(defrule (a :grammar #:grammar-inclusion.redefinition-with-removed-use.foo)
+    "a")
+(defgrammar #:grammar-inclusion.redefinition-with-removed-use.bar
+  (:use #:grammar-inclusion.redefinition-with-removed-use.foo))
+(defrule (b :grammar #:grammar-inclusion.redefinition-with-removed-use.bar)
+    a)
+
+(test grammar-inclusion.redefinition-with-removed-use
+  "Test using a grammar and then redefining the downstream grammar to
+no longer use the upstream grammar."
+  (is (string= (parse 'b "a" :grammar '#:grammar-inclusion.redefinition-with-removed-use.bar) "a"))
+
+  (defgrammar #:grammar-inclusion.redefinition-with-removed-use.bar)
+
+  (signals rule-not-found-error
+    (parse 'b "a" :grammar '#:grammar-inclusion.redefinition-with-removed-use.bar)))
+
+;;; GRAMMAR-INCLUSION.CIRCULAR-DEPENDENCY
+
+(test grammar-inclusion.circular-dependency
+  "Check signaled error in case of cyclic dependencies between
+grammars."
+  (eval '(progn
+          ;; Clear uses in case the test is run multiple times.
+          (defgrammar #:grammar-inclusion.circular-dependency.a)
+          (defgrammar #:grammar-inclusion.circular-dependency.b)
+
+          ;; Now setup the circular dependency.
+          (defgrammar #:grammar-inclusion.circular-dependency.b
+            (:use #:grammar-inclusion.circular-dependency.a))
+          (signals simple-error
+            (defgrammar #:grammar-inclusion.circular-dependency.a
+              (:use #:grammar-inclusion.circular-dependency.b))))))
+
+;;; Simple test grammar
+
+(defgrammar #:test)
+(in-grammar #:test)
+
+;; A few semantic predicates
 
 (defun not-doublequote (char)
   (not (eql #\" char)))
@@ -43,7 +407,7 @@
 (defun not-space (char)
   (not (eql #\space char)))
 
-;;;; Utility rules
+;; Utility rules
 
 (defrule whitespace (+ (or #\space #\tab #\newline))
   (:text t))
@@ -85,18 +449,86 @@
           (declare (ignore comma))
           (cons int list)))))
 
-(test smoke
+(test parse.check-expression
+  "Test expression checking in DEFRULE."
+  ;; The compiler-macro on PARSE should signal compile-time warnings
+  ;; for invalid expressions.
+  (compilation-signals invalid-expression-warning
+    (parse '(~ 1) "a"))
+  (compilation-signals invalid-expression-warning
+    (parse '(~ 1) "a" :grammar '#:test))
+
+  ;; When ignoring compile-time warnings, PARSE should signal errors
+  ;; at runtime for invalid expressions.
+  (macrolet ((is-invalid-expr (&body body)
+               `(signals invalid-expression-error
+                  (ignoring-compile-time-warnings (invalid-expression-warning)
+                    ,@body))))
+    (is-invalid-expr (parse '(~ 1) "a"))
+    (is-invalid-expr (parse '(~ 1) "a" :grammar '#:test))
+    (is-invalid-expr (parse '(string) "a"))
+    (is-invalid-expr (parse '(character-ranges 1) "a"))
+    (is-invalid-expr (parse '(character-ranges (#\a)) "a"))
+    (is-invalid-expr (parse '(character-ranges (#\a #\b #\c)) "a"))
+    (is-invalid-expr (parse '(and (string)) "a"))
+    (is-invalid-expr (parse '(not) "a"))))
+
+(test parse.smoke
+  "Smoke test for PARSE."
   (is (equal '("1," "2," "" "3," "4.")
              (parse 'trimmed-lines "1,
                                     2,
 
                                     3,
-                                    4.")))
-  (is (eql 123 (parse 'integer "  123")))
-  (is (eql 123 (parse 'integer "  123  ")))
-  (is (eql 123 (parse 'integer "123  ")))
-  (is (equal '(123 45 6789 0) (parse 'list-of-integers "123, 45  ,   6789, 0")))
-  (is (equal '(123 45 6789 0) (parse 'list-of-integers "  123 ,45,6789, 0  "))))
+                                    4."
+                    :grammar '#:test)))
+  (is (eql 123 (parse 'integer "  123" :grammar '#:test)))
+  (is (eql 123 (parse 'integer "  123  " :grammar '#:test)))
+  (is (eql 123 (parse 'integer "123  " :grammar '#:test)))
+  (is (equal '(123 45 6789 0)
+             (parse 'list-of-integers "123, 45  ,   6789, 0" :grammar '#:test)))
+  (is (equal '(123 45 6789 0)
+             (parse 'list-of-integers "  123 ,45,6789, 0  " :grammar '#:test))))
+
+(test parse.default-grammar
+  "Test PARSE with default grammar."
+  (let ((*grammar* (find-grammar '#:test)))
+    (is (eql 123 (parse 'integer "  123")))
+    (is (eql 123 (parse 'integer "  123  ")))
+    (is (eql 123 (parse 'integer "123  ")))))
+
+(test parse.non-existent-grammar
+  "Test compile-time and runtime conditions signaled by PARSE for
+non-existent grammars."
+  ;; See defgrammar.use-non-existent.
+  (compilation-signals grammar-not-found-warning
+    (parse 'does-not-matter "foo" :grammar '#:does-not-exist))
+
+  (signals grammar-not-found-error
+    (ignoring-compile-time-warnings (grammar-not-found-warning)
+      (parse 'does-not-matter "foo" :grammar '#:does-not-exist))))
+
+(defgrammar #:parse.non-existent-rule)
+
+(test parse.non-existent-rule
+  "Test compile-time and runtime conditions signaled by PARSE for
+non-existent rules."
+  ;; See defgrammar.use-non-existent.
+  (compilation-signals rule-not-found-warning
+    (parse 'does-not-exist "foo"
+           :grammar '#:parse.non-existent-rule))
+  (compilation-signals rule-not-found-warning
+    (parse '(+ (or "a" does-not-exist)) "foo"
+           :grammar '#:parse.non-existent-rule))
+
+  (signals rule-not-found-error
+    (ignoring-compile-time-warnings (rule-not-found-warning)
+      (parse 'does-not-exist "foo"
+             :grammar '#:parse.non-existent-rule)))
+  (signals rule-not-found-error
+    (ignoring-compile-time-warnings (rule-not-found-warning)
+      (parse '(+ (or "a" does-not-exist)) "foo"
+             :grammar '#:parse.non-existent-rule))))
 
 (defrule single-token/bounds.1 (+ (not-space character))
   (:lambda (result &bounds start end)
@@ -130,21 +562,22 @@
 
 (defrule left-recursion (and left-recursion "l"))
 
-(test bounds.1
+(test parse.bounds.1
+  "First test for PARSE with bounds retrieval."
   (is (equal '("foo[0-3]")
-             (parse 'tokens/bounds.1 "foo")))
+             (parse 'tokens/bounds.1 "foo" :grammar '#:test)))
   (is (equal '("foo[0-3]" "bar[4-7]" "quux[11-15]")
-             (parse 'tokens/bounds.1 "foo bar    quux"))))
+             (parse 'tokens/bounds.1 "foo bar    quux" :grammar '#:test))))
 
-(test bounds.2
+(test parse.bounds.2
+  "Second test for PARSE with bounds retrieval."
   (is (equal '("foo(0-3)")
-             (parse 'tokens/bounds.2 "foo")))
+             (parse 'tokens/bounds.2 "foo" :grammar '#:test)))
   (is (equal '("foo(0-3)" "bar(4-7)" "quux(11-15)")
-             (parse 'tokens/bounds.2 "foo bar    quux"))))
+             (parse 'tokens/bounds.2 "foo bar    quux" :grammar '#:test))))
 
-(test condition.1
-  "Test signaling of `esrap-simple-parse-error' conditions for failed
-   parses."
+(test parse.condition.1
+  "Test signaling of ESRAP-ERROR conditions for failed parses."
   (macrolet
       ((signals-esrap-error ((input position &optional messages) &body body)
          `(progn
@@ -161,19 +594,19 @@
                                   (ensure-list messages))))))))))
     (signals-esrap-error ("" 0 ("Could not parse subexpression"
                                 "Encountered at"))
-      (parse 'integer ""))
+      (parse 'integer "" :grammar '#:test))
     (signals-esrap-error ("123foo" 3 ("Could not parse subexpression"
                                       "Encountered at"))
-      (parse 'integer "123foo"))
+      (parse 'integer "123foo" :grammar '#:test))
     (signals-esrap-error ("1, " 1 ("Incomplete parse."
                                    "Encountered at"))
-      (parse 'list-of-integers "1, "))))
+      (parse 'list-of-integers "1, " :grammar '#:test))))
 
-(test condition.2
-  "Test signaling of `left-recursion' condition."
+(test parse.condition.2
+  "Test signaling of LEFT-RECURSION condition."
   (signals (left-recursion)
-    (parse 'left-recursion "l"))
-  (handler-case (parse 'left-recursion "l")
+    (parse 'left-recursion "l" :grammar '#:test))
+  (handler-case (parse 'left-recursion "l" :grammar '#:test)
     (left-recursion (condition)
       (is (string= (esrap-error-text condition) "l"))
       (is (= (esrap-error-position condition) 0))
@@ -182,15 +615,21 @@
       (is (equal (left-recursion-path condition)
                  '(left-recursion left-recursion))))))
 
-(test negation
+(test parse.negation
   "Test negation in rules."
   (let* ((text "FooBazBar")
-         (t1c (text (parse '(+ (not "Baz")) text :junk-allowed t)))
-         (t1e (text (parse (identity '(+ (not "Baz"))) text :junk-allowed t)))
-         (t2c (text (parse '(+ (not "Bar")) text :junk-allowed t)))
-         (t2e (text (parse (identity '(+ (not "Bar"))) text :junk-allowed t)))
-         (t3c (text (parse '(+ (not (or "Bar" "Baz"))) text :junk-allowed t)))
-         (t3e (text (parse (identity '(+ (not (or "Bar" "Baz")))) text :junk-allowed t))))
+         (t1c (text (parse '(+ (not "Baz")) text
+                           :grammar '#:test :junk-allowed t)))
+         (t1e (text (parse (identity '(+ (not "Baz"))) text
+                           :grammar '#:test :junk-allowed t)))
+         (t2c (text (parse '(+ (not "Bar")) text
+                           :grammar '#:test :junk-allowed t)))
+         (t2e (text (parse (identity '(+ (not "Bar"))) text
+                           :grammar '#:test :junk-allowed t)))
+         (t3c (text (parse '(+ (not (or "Bar" "Baz"))) text
+                           :grammar '#:test :junk-allowed t)))
+         (t3e (text (parse (identity '(+ (not (or "Bar" "Baz")))) text
+                           :grammar '#:test :junk-allowed t))))
     (is (equal "Foo" t1c))
     (is (equal "Foo" t1e))
     (is (equal "FooBaz" t2c))
@@ -232,18 +671,18 @@
                        (list (cons 0 (cons start end))))))
       (call-transform))))
 
-(test around.1
+(test parse.around.1
   "Test executing code around the transform of a rule."
   (macrolet ((test-case (input expected)
-               `(is (equal (parse 'around.1 ,input) ,expected))))
+               `(is (equal (parse 'around.1 ,input :grammar '#:test) ,expected))))
     (test-case "foo"     '((0) . "foo"))
     (test-case "{bar}"   '((1 0) . "bar"))
     (test-case "{{baz}}" '((2 1 0) . "baz"))))
 
-(test around.2
+(test parse.around.2
   "Test executing code around the transform of a rule."
   (macrolet ((test-case (input expected)
-               `(is (equal (parse 'around.2 ,input) ,expected))))
+               `(is (equal (parse 'around.2 ,input :grammar '#:test) ,expected))))
     (test-case "foo"     '(((0 . (0 . 3)))
                            . "foo"))
     (test-case "{bar}"   '(((1 . (1 . 4))
@@ -256,13 +695,20 @@
 
 (defrule character-range (character-ranges (#\a #\b) #\-))
 
-(test character-range-test
-  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab" :junk-allowed t)))
-  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab1" :junk-allowed t)))
-  (is (equal '(#\a #\b #\-) (parse '(* (character-ranges (#\a #\z) #\-)) "ab-" :junk-allowed t)))
-  (is (not (parse '(* (character-ranges (#\a #\z) #\-)) "AB-" :junk-allowed t)))
-  (is (not (parse '(* (character-ranges (#\a #\z) #\-)) "ZY-" :junk-allowed t)))
-  (is (equal '(#\a #\b #\-) (parse '(* character-range) "ab-cd" :junk-allowed t))))
+(test parse.character-range.smoke
+  "Smoke test for parsing character ranges."
+  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab"
+                               :grammar '#:test :junk-allowed t)))
+  (is (equal '(#\a #\b) (parse '(* (character-ranges (#\a #\z) #\-)) "ab1"
+                               :grammar '#:test :junk-allowed t)))
+  (is (equal '(#\a #\b #\-) (parse '(* (character-ranges (#\a #\z) #\-)) "ab-"
+                                   :grammar '#:test :junk-allowed t)))
+  (is (not (parse '(* (character-ranges (#\a #\z) #\-)) "AB-"
+                  :grammar '#:test :junk-allowed t)))
+  (is (not (parse '(* (character-ranges (#\a #\z) #\-)) "ZY-"
+                  :grammar '#:test :junk-allowed t)))
+  (is (equal '(#\a #\b #\-) (parse '(* character-range) "ab-cd"
+                                   :grammar '#:test :junk-allowed t))))
 
 (defun run-tests ()
   (let ((results (run 'esrap)))


### PR DESCRIPTION
This is a prototype implementation of package-like grammars. It is prototypical in the sense that much cleanup and some refactoring is necessary. However, I wanted to try and get some feedback before polishing this any further. Thanks for taking the time to consider this.

Commit message:

```
* Partly based on menschenkindlein's
  implementation
  (Menschenkindlein/esrap@63baec4e20591d3c1517fae88a364de8a39ebb12).

* Grammar objects are a bit like CL packages:

  * they have a name and optional :DOCUMENTATION
  * they can :USE other grammars
  * they act as containers for rules
  * redefinition is allowed and preserves existing rules

* Changed interface:

  * GRAMMAR-NOT-FOUND-{ERROR,WARNING} [condition]
  * RULE-NOT-FOUND-{ERROR,WARNING}    [condition]

  * GRAMMAR-NAME                      [function]
  * GRAMMAR-DEPENDENCIES              [function]
  * GRAMMAR-RULES                     [function]

  * DEFGRAMMAR                        [macro]
  * IN-GRAMMAR                        [macro]

  * MAKE-GRAMMAR                      [function]
  * FIND-GRAMMAR                      [function]
  * (SETF FIND-GRAMMAR)               [function]

  * DEFGRAMMAR, DEFRULE and PARSE signal full warnings at compile time
    when constant references to grammars or rules cannot be resolved.

  * IMPORTANT: In addition, all user-visible -rule functions take a
    grammar designator as their first argument.

* Changed implementation:

  * DEFGRAMMAR, IN-GRAMMAR and DEFRULE produce code which is evaluated
    at compile-, load- and runtime. This is necessary in order to be
    able to define and use a grammar in the same file.

  * FIND-RULE traverses used grammars to find the requested rule.

  * The new functions UPDATE-RULE-DEPENDENCIES, RECOMPILE-CELL are
    called after adding/removing rules/used grammars to update
    dependencies and recompile rules.

  * Rule dependencies are expressed in terms of referencing rule
    cells, not symbols.

* New tests for grammar objects and related lookup and redefinition
  issues have been added.

* Documentation has been extended.

* Examples:

  * example-sexp.lisp now uses a separate grammar called SEXP

  * example-sexp-xml.lisp contains a new grammar called XML which uses
    the SEXP grammar to demonstrate grammar dependencies (originally
    written by Menschenkindlein)
```

There are design decision, for which I could use some advice:
1. Is backwards compatibility to the previous

``` cl
(parse RULE STRING)
```

interface required?
1. Rule names are currently processed using `STRING`. This allows clients to write 

``` cl
(parse '#:some-grammar '#:some-rule TEXT)
```

. It also frees grammar writers from exporting rule names as symbols. However, it could lead to clashes between rule names in the `USE`-closure of some grammar. It also prevents "private" rules. 
1. Should operations on grammars accept grammar objects and grammar
   designators or should the idiom instead always be

``` cl
(grammar-name (find-grammar GRAMMAR-DESIGNATOR))
```

   ?
1. Should operations on rules accept grammar and rule designators as in

``` cl
(rule-dependencies GRAMMAR-DESIGNATOR RULE-DESIGNATOR)
```

   or should these operations accept rule objects as in

``` cl
(rule-dependencies (find-rule GRAMMAR-DESIGNATOR RULE-DESIGNATOR))
```

   or even

``` cl
(rule-dependencies (find-rule (find-grammar GRAMMAR-DESIGNATOR) RULE-DESIGNATOR))
```

   ?
5. Should circular dependencies between grammars be allowed? Currently, they signal an error.
1. The `*non-existent*` tests use some compilation/signal-related trickery which can probably be improved.
2. Redefinition of whole grammars (via `(setf (find-grammar ...) nil)` and then `(defgrammar ...)`) after `(parse ...)` calls have been compile-time optimized can lead to an old definition of a rule being used.
