### PR TITLE
Support left recursive rules with potential performance hit

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,11 @@ References:
 
     http://pdos.csail.mit.edu/~baford/packrat/thesis/
 
+  * A. Warth et al, 2008, "Packrat Parsers Can Support Left
+    Recursion".
+
+    http://www.vpri.org/pdf/tr2007002_packrat.pdf
+
 Licence:
 
  Copyright (c) 2007-2011 Nikodemus Siivola <nikodemus@sb-studio.net>

--- a/doc/esrap.texinfo
+++ b/doc/esrap.texinfo
@@ -48,6 +48,10 @@ For more on packrat parsing, see
 @url{http://pdos.csail.mit.edu/~baford/packrat/thesis/} for Bryan Ford's 2002
 thesis: ``Packrat Parsing: a Practical Linear Time Algorithm with Backtracking''.
 
+For left recursion support in packrat parsers, see
+@url{http://www.vpri.org/pdf/tr2007002_packrat.pdf} for A. Warth et al's
+2008 paper: ``Packrat Parsers Can Support Left Recursion''.
+
 @contents
 
 @ifnottex
@@ -202,6 +206,24 @@ semantic predicate produces whatever the subexpression produces.
 @emph{Note: semantic predicates may change in the future to produce
 whatever the predicate function returns.}
 
+@heading Left Recursion
+
+One aspect of designing Esrap rules is @emph{left recursion}. A
+@emph{direct left recursive} rule is of the form
+@lisp
+(defrule left-recursion (or (and left-recursion STUFF) ALTERNATIVES))
+@end lisp
+The simplest @emph{indirect left recursive} rule is of the form
+@lisp
+(defrule left-recursion.1 left-recursion.2)
+(defrule left-recursion.2 (or (and left-recursion.1 STUFF) ALTERNATIVES))
+@end lisp
+
+Esrap can handle both kinds of left recursive rules, but the linear-time
+guarantee generally no longer holds in such cases. The special variable
+@code{*error-on-left-recursion*} can be used to control Esrap's behavior
+with respect to allowing left recursion.
+
 @chapter Dictionary
 
 @section Primary Interface
@@ -228,6 +250,8 @@ whatever the predicate function returns.}
 @include include/fun-esrap-untrace-rule.texinfo
 
 @section Error Conditions
+
+@include include/var-esrap-star-error-on-left-recursion-star.texinfo
 
 @include include/condition-esrap-esrap-error.texinfo
 @include include/condition-esrap-left-recursion.texinfo

--- a/esrap.asd
+++ b/esrap.asd
@@ -22,7 +22,7 @@
 (in-package :esrap-system)
 
 (defsystem :esrap
-  :version "0.9"
+  :version "0.10"
   :description "A Packrat / Parsing Grammar / TDPL parser for Common Lisp."
   :licence "MIT"
   :depends-on (:alexandria)
@@ -30,6 +30,10 @@
                (:static-file "example-sexp.lisp")
                (:static-file "example-symbol-table.lisp")
                (:static-file "README")))
+
+(defmethod perform :after ((op load-op) (sys (eql (find-system :esrap))))
+  ;; Since version 0.10
+  (pushnew :esrap.can-handle-left-recursion *features*))
 
 (defsystem :esrap-tests
   :description "Tests for ESRAP."

--- a/esrap.lisp
+++ b/esrap.lisp
@@ -11,6 +11,10 @@
 ;;;;     Algorithm with Backtracking".
 ;;;;     http://pdos.csail.mit.edu/~baford/packrat/thesis/
 ;;;;
+;;;;   * Alessandro Warth, James R. Douglass, Todd Millstein, 2008,
+;;;;     "Packrat Parsers Can Support Left Recursion".
+;;;;     http://www.vpri.org/pdf/tr2007002_packrat.pdf
+;;;;
 ;;;; Licence:
 ;;;;
 ;;;;  Permission is hereby granted, free of charge, to any person
@@ -38,6 +42,8 @@
 
    #:! #:? #:+ #:* #:& #:~
    #:character-ranges
+
+   #:*error-on-left-recursion*
 
    #:add-rule
    #:call-transform
@@ -149,10 +155,14 @@ the error occurred."))
   ((nonterminal :initarg :nonterminal :initform nil :reader left-recursion-nonterminal)
    (path :initarg :path :initform nil :reader left-recursion-path))
   (:documentation
-   "Signaled when left recursion is detected during Esrap parsing.
-LEFT-RECURSION-NONTERMINAL names the symbol for which left recursion was
-detected, and LEFT-RECURSION-PATH lists nonterminals of which the left
-recursion cycle consists."))
+   "May be signaled when left recursion is detected during Esrap parsing.
+
+LEFT-RECURSION-NONTERMINAL names the symbol for which left recursion
+was detected, and LEFT-RECURSION-PATH lists nonterminals of which the
+left recursion cycle consists.
+
+Note: This error is only signaled if *ERROR-ON-LEFT-RECURSION* is
+bound to a non-NIL value."))
 
 (defmethod print-object :before ((condition left-recursion) stream)
   (format stream "Left recursion in nonterminal ~S. ~_Path: ~
@@ -160,7 +170,26 @@ recursion cycle consists."))
           (left-recursion-nonterminal condition)
           (left-recursion-path condition)))
 
+(defun left-recursion (text position nonterminal path-butlast)
+  (error 'left-recursion
+         :text text
+         :position position
+         :nonterminal nonterminal
+         :path (append path-butlast (list nonterminal))))
+
 ;;; Miscellany
+
+(declaim (special *error-on-left-recursion*))
+
+(defvar *error-on-left-recursion* nil
+  "This special variable can be used to control Esrap's behavior with
+respect to allowing left recursion.
+
+When non-NIL, PARSE signals an error when it encounters a left
+recursive rule. Otherwise the rule is processed.
+
+Note: when processing left recursive rules, linear-time guarantees
+generally no longer hold.")
 
 (defun text (&rest arguments)
   "Arguments must be strings, or lists whose leaves are strings.
@@ -443,27 +472,123 @@ symbols."
 (defun (setf get-cached) (result symbol position cache)
   (setf (gethash (cons symbol position) cache) result))
 
+;; In case of left recursion, this stores
+(defstruct head
+  ;; the rule at which the left recursion started
+  (rule (required-argument) :type symbol)
+  ;; the set of involved rules
+  (involved-set '() :type list)
+  ;; and the set of rules which rules which can still be applied in
+  ;; the current round of "seed parse" growing
+  (eval-set '() :type list))
+
+(defvar *heads*)
+
+(defun make-heads ()
+  (make-hash-table :test #'equal))
+
+(defun get-head (position heads)
+  (gethash position heads))
+
+(defun (setf get-head) (head position heads)
+  (setf (gethash position heads) head))
+
+(defun recall (rule position cache heads thunk)
+  (let ((result (get-cached rule position cache))
+        (head (get-head position heads)))
+    (cond
+      ;; If not growing a seed parse, just return what is stored in
+      ;; the cache.
+      ((not head)
+       result)
+      ;; Do not evaluate any rule that is not involved in this left
+      ;; recursion.
+      ((and (not result) (not (or (eq rule (head-rule head))
+                             (member rule (head-involved-set head)))))
+       (make-failed-parse :position position))
+      ;; Allow involved rules to be evaluated, but only once, during a
+      ;; seed-growing iteration. Subsequent requests just return what
+      ;; is stored in the cache.
+      (t
+       (when (member rule (head-eval-set head))
+         (removef (head-eval-set head) rule :count 1)
+         (setf result (funcall thunk position)
+               (get-cached rule position cache) result))
+       result))))
+
 (defvar *nonterminal-stack* nil)
 
-;;; SYMBOL, POSITION, and CACHE must all be lexical variables!
+;;; SYMBOL and POSITION must all lexical variables!
 (defmacro with-cached-result ((symbol position &optional (text nil)) &body forms)
-  (with-gensyms (cache result)
-    `(let* ((,cache *cache*)
-            (,result (get-cached ,symbol ,position ,cache))
-            (*nonterminal-stack* (cons ,symbol *nonterminal-stack*)))
-       (cond ((eq t ,result)
-              (error 'left-recursion
-                     :text ,text
-                     :position ,position
-                     :nonterminal ,symbol
-                     :path (reverse *nonterminal-stack*)))
-             (,result
-              ,result)
-             (t
-              ;; First mark this pair with T to detect left-recursion,
-              ;; then compute the result and cache that.
-              (setf (get-cached ,symbol ,position ,cache) t
-                    (get-cached ,symbol ,position ,cache) (locally ,@forms)))))))
+  (with-gensyms (cache heads result)
+    `(flet ((do-it (position) ,@forms))
+       (let* ((,cache *cache*)
+              (,heads *heads*)
+              (,result (recall ,symbol ,position ,cache ,heads #'do-it)))
+         (cond
+           ;; Found left-recursion marker in the cache. Depending on
+           ;; *ERROR-ON-LEFT-RECURSION*, we either signal an error or
+           ;; prepare recovery from this situation (which is performed
+           ;; by one of the "cache miss" cases (see below) up the
+           ;; call-stack).
+           ((left-recursion-result-p ,result)
+            ;; If error on left-recursion has been requested, do that.
+            (when *error-on-left-recursion*
+              (left-recursion ,text,position ,symbol
+                              (reverse (mapcar #'left-recursion-result-rule
+                                               *nonterminal-stack*))))
+            ;; Otherwise, mark left recursion and fail this partial
+            ;; parse.
+            (let ((head (or (left-recursion-result-head ,result)
+                            (setf (left-recursion-result-head ,result)
+                                  (make-head :rule ,symbol)))))
+              ;; Put this head into left recursion markers on the
+              ;; stack. Add rules on the stack to the "involved set".
+              (dolist (item *nonterminal-stack*)
+                (when (eq (left-recursion-result-head item) head)
+                  (return))
+                (setf (left-recursion-result-head item) head)
+                (pushnew (left-recursion-result-rule item)
+                         (head-involved-set head))))
+            (make-failed-parse :expression ,symbol
+                               :position ,position))
+           ;; Cache hit without left-recursion.
+           (,result
+            ,result)
+           ;; Cache miss.
+           (t
+            ;; First add a left recursion marker for this pair, then
+            ;; compute the result, potentially recovering from left
+            ;; recursion and cache that.
+            (let* ((result (make-left-recursion-result :rule ,symbol))
+                   (result1
+                     (let ((*nonterminal-stack* (cons result *nonterminal-stack*)))
+                       (setf (get-cached ,symbol ,position ,cache)
+                             result
+                             (get-cached ,symbol ,position ,cache)
+                             (do-it position)))))
+              ;; If we detect left recursion, handle it.
+              (when (and (not (error-result-p result1))
+                         (left-recursion-result-head result))
+                (let ((head (left-recursion-result-head result)))
+                  ;; Grow "seed parse" (grow-lr in the paper):
+                  ;; repeatedly apply rules involved in left-recursion
+                  ;; until no progress can be made.
+                  (setf (get-head ,position ,heads) head)
+                  (loop
+                    (setf (head-eval-set head)
+                          (copy-list (head-involved-set head)))
+                    (let ((result2 (do-it ,position)))
+                      (when (or (error-result-p result2)
+                                (<= (result-position result2)
+                                    (result-position result1))) ; no progress
+                        (return))
+                      (setf (get-cached ,symbol ,position ,cache)
+                            (%make-result :position (result-position result2)
+                                          :%production (result-%production result2))
+                            result1 result2)))
+                  (setf (get-head ,position ,heads) nil)))
+              result1)))))))
 
 ;;; RESULT REPRESENTATION
 ;;;
@@ -486,6 +611,12 @@ symbols."
   (position (required-argument) :type array-index)
   ;; A nested error, closer to actual failure site.
   detail)
+
+;; This is placed in the cache as a place in which information
+;; regarding left recursion can be stored temporarily.
+(defstruct (left-recursion-result (:include error-result))
+  (rule (required-argument) :type symbol)
+  (head nil :type (or null head)))
 
 (defstruct (result (:constructor %make-result))
   ;; Either a list of results, whose first element is the production, or a
@@ -520,10 +651,11 @@ are allowed only if JUNK-ALLOWED is true."
   ;; There is no backtracking in the toplevel expression -- so there's
   ;; no point in compiling it as it will be executed only once -- unless
   ;; it's a constant, for which we have a compiler-macro.
-  (let ((end (or end (length text))))
+  (let ((end (or end (length text)))
+        (*cache* (make-cache))
+        (*heads* (make-heads)))
     (process-parse-result
-     (let ((*cache* (make-cache)))
-       (eval-expression expression text start end))
+     (eval-expression expression text start end)
      text
      end
      junk-allowed)))
@@ -538,6 +670,7 @@ are allowed only if JUNK-ALLOWED is true."
            ;; about evaluation order.
            ((lambda (text &key (start 0) end junk-allowed)
               (let ((*cache* (make-cache))
+                    (*heads* (make-heads))
                     (end (or end (length text))))
                 (process-parse-result
                  (funcall ,expr-fun text start end)

--- a/example-left-recursion.lisp
+++ b/example-left-recursion.lisp
@@ -1,0 +1,143 @@
+;;;; Esrap example: some grammars with left-recursive rules.
+
+(require :esrap)
+
+(defpackage :left-recursive-grammars
+  (:use :cl :alexandria :esrap))
+
+(in-package :left-recursive-grammars)
+
+;;; Left associative expressions
+
+(defrule la-expr
+    la-term)
+
+(defrule la-literal
+    (digit-char-p character)
+  (:lambda (x) (parse-integer (text x))))
+
+(defrule la-term
+    (and la-factor (? (and (or #\+ #\-) la-term)))
+  (:destructure (left (&optional op right))
+    (if op
+        (list (find-symbol op :cl) left right)
+        left)))
+
+(defrule la-factor
+    (and (or la-literal la-expr) (? (and (or #\* #\/) la-factor)))
+  (:destructure (left (&optional op right))
+    (if op
+        (list (find-symbol op :cl) left right)
+        left)))
+
+(let ((esrap:*error-on-left-recursion* t))
+  (assert (equal (parse 'la-expr "1*2+3*4+5") '(+ (* 1 2) (+ (* 3 4) 5)))))
+
+;;; Right associative expressions
+
+(defrule ra-expr
+    ra-term)
+
+(defrule ra-literal
+    (digit-char-p character)
+  (:lambda (x) (parse-integer (text x))))
+
+(defrule ra-term
+    (and (? (and ra-term (or #\+ #\-))) ra-factor)
+  (:destructure ((&optional left op) right)
+    (if op
+        (list (find-symbol op :cl) left right)
+        right)))
+
+(defrule ra-factor
+    (and (? (and ra-factor (or #\* #\/))) (or ra-literal ra-expr))
+  (:destructure ((&optional left op) right)
+    (if op
+        (list (find-symbol op :cl) left right)
+        right)))
+
+(when nil
+  (let ((esrap:*error-on-left-recursion* t))
+    (parse 'ra-expr "1*2+3*4+5")) ; |- Error
+  )
+
+(assert (equal (parse 'ra-expr "1*2+3*4+5")
+               '(+ (+ (* 1 2) (* 3 4)) 5)))
+
+;;; The following example is given in
+;;;
+;;;   Alessandro Warth, James R. Douglass, Todd Millstein, 2008,
+;;;   "Packrat Parsers Can Support Left Recursion".
+;;;   http://www.vpri.org/pdf/tr2007002_packrat.pdf
+
+(defrule primary
+    primary-no-new-array)
+
+(defrule primary-no-new-array
+    (or class-instance-creation-expression
+        method-invocation
+        field-access
+        array-access
+        "this"))
+
+(defrule class-instance-creation-expression
+    (or (and "new" class-or-interface-type "()")
+        (and primary ".new" identifier "()")))
+
+;; Note: in the paper, the first case is
+;;
+;;   (and primary "." identifier "()")
+;;
+;; but that seems to be an error.
+(defrule method-invocation
+    (or (and primary "." method-name "()")
+        (and (and) (and) method-name "()"))
+  (:destructure (structure dot name parens)
+    (declare (ignore dot parens))
+    (list :method-invocation structure name)))
+
+(defrule field-access
+    (or (and primary "." identifier)
+        (and "super." identifier))
+  (:destructure (structure dot field)
+    (declare (ignore dot))
+    (list :field-access structure field)))
+
+(defrule array-access
+    (or (and primary "[" expression "]")
+        (and expression-name "[" expression "]"))
+  (:destructure (structure open index close)
+    (declare (ignore open close))
+    (list :array-access structure index)))
+
+(defrule class-or-interface-type
+    (or class-name interface-type-name))
+
+(defrule class-name
+    (or "C" "D"))
+
+(defrule interface-type-name
+    (or "I" "J"))
+
+(defrule identifier
+    (or "x" "y" class-or-interface-type))
+
+(defrule method-name
+    (or "m" "n"))
+
+(defrule expression-name
+    identifier)
+
+(defrule expression
+    (or "i" "j"))
+
+
+(mapc
+ (curry #'apply
+        (lambda (input expected)
+          (assert (equal (parse 'primary input) expected))))
+ '(("this"       "this")
+   ("this.x"     (:field-access "this" "x"))
+   ("this.x.y"   (:field-access (:field-access "this" "x") "y"))
+   ("this.x.m()" (:method-invocation (:field-access "this" "x") "m"))
+   ("x[i][j].y"  (:field-access (:array-access (:array-access "x" "i") "j") "y"))))


### PR DESCRIPTION
I implemented the strategy introduced in

> Alessandro Warth, James R. Douglass, Todd Millstein, 2008,
> "Packrat Parsers Can Support Left Recursion".
> http://www.vpri.org/pdf/tr2007002_packrat.pdf

Unfortunately, I'm not completely sure that my implementation is correct. I tested as thoroughly as I could but the algorithm is rather complicated. However, this is probably not as bad as it sounds because existing grammars are not affected by the added code. I did the following things to test the code:
- test cases for direct and indirect left recursion with various input sizes
- examples for left- and right-associative arithmetic expression grammars
- an example reproducing the grammar given as an example in the above paper
  the new examples can be found in `example-left-recursion.lisp`.

Commit message

```
Support left recursive rules with potential performance hit

As described in

  Alessandro Warth, James R. Douglass, Todd Millstein, 2008,
  "Packrat Parsers Can Support Left Recursion".
  http://www.vpri.org/pdf/tr2007002_packrat.pdf

WITH-CACHED-RESULT detects left recursion and (unless signaling an
error has been requested) handles the situation by growing a "seed
parse" via repeated application of the rules involved in the left
recursion.

The new special variable *ERROR-ON-LEFT-RECURSION* switches between
this new behavior and the old behavior of signaling a LEFT-RECURSION
error.

The system version has been bumped from 0.9 to 0.10 and a feature
:ESRAP-CAN-HANDLE-LEFT-RECURSION is pushed onto *FEATURES* when the
system is loaded.

Basic unit tests for direct and indirect left recursion have been
added.

The manual has been extended.

The new file example-left-recursion.lisp contains multiple grammars
which exercise and illustrate the new capability.
```
